### PR TITLE
docs: add PR-first workflow and pull cadence

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ cargo test
 ## Docs
 - `docs/ARCHITECTURE.md`
 - `docs/MISSION_PLAN.md`
+- `docs/CONTRIBUTING_WORKFLOW.md`

--- a/docs/CONTRIBUTING_WORKFLOW.md
+++ b/docs/CONTRIBUTING_WORKFLOW.md
@@ -1,0 +1,35 @@
+# Contributing Workflow
+
+## Default Workflow (PR-First)
+
+1. Sync often:
+```bash
+git checkout main
+git pull --ff-only
+```
+
+2. Create a focused branch:
+```bash
+git checkout -b feat/<short-topic>
+```
+
+3. Make small, testable changes.
+
+4. Re-sync before push:
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+5. Push and open a PR:
+```bash
+git push -u origin feat/<short-topic>
+gh pr create --base main --head feat/<short-topic>
+```
+
+## Team Norms
+
+- Open PRs often, even for small increments.
+- Prefer multiple small PRs over large batches.
+- Pull (`git pull --ff-only`) frequently to avoid drift.
+- Keep PRs single-purpose with clear scope and evidence.


### PR DESCRIPTION
## Summary
- add `docs/CONTRIBUTING_WORKFLOW.md` with PR-first workflow
- document frequent `git pull --ff-only` and rebase cadence
- link workflow doc from `README.md`

## Why
To standardize a fast, low-drift development loop: pull often and open PRs often.

## Notes
This is process guidance only (no runtime behavior changes).
