### PR TITLE
fix: harden scaffold — fallible ID gen, serde tests, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
 /build
-Cargo.lock
-.wrangler
+/worker/generated
+/.wrangler
 node_modules

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .post_async("/v1/runs", |mut req, _ctx| async move {
             let body: models::CreateRun = req.json().await?;
             Response::from_json(&models::RunCreated {
-                id: generate_id(),
+                id: generate_id()?,
                 status: "created".into(),
                 repo: body.repo,
             })
@@ -42,7 +42,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .post_async("/v1/events", |mut req, _ctx| async move {
             let body: models::ProvenanceEvent = req.json().await?;
             Response::from_json(&models::EventAck {
-                id: generate_id(),
+                id: generate_id()?,
                 event_type: body.event_type,
                 accepted: true,
             })
@@ -74,8 +74,8 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .await
 }
 
-fn generate_id() -> String {
+fn generate_id() -> Result<String> {
     let mut buf = [0u8; 16];
-    getrandom::getrandom(&mut buf).unwrap();
-    hex::encode(buf)
+    getrandom::getrandom(&mut buf).map_err(|e| Error::RustError(e.to_string()))?;
+    Ok(hex::encode(buf))
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,14 +2,14 @@ use serde::{Deserialize, Serialize};
 
 // ── Runs (WS2: core domain entity) ─────────────────────────────
 
-#[derive(Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CreateRun {
     pub repo: String,
     pub trigger: Option<String>,
     pub metadata: Option<serde_json::Value>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct RunCreated {
     pub id: String,
     pub status: String,
@@ -18,7 +18,7 @@ pub struct RunCreated {
 
 // ── Provenance Events (WS3: append-only audit trail) ────────────
 
-#[derive(Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ProvenanceEvent {
     pub run_id: String,
     pub event_type: String,
@@ -26,7 +26,7 @@ pub struct ProvenanceEvent {
     pub payload: Option<serde_json::Value>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct EventAck {
     pub id: String,
     pub event_type: String,
@@ -35,7 +35,7 @@ pub struct EventAck {
 
 // ── Policy (WS4: governance layer) ──────────────────────────────
 
-#[derive(Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct PolicyCheckRequest {
     pub action: String,
     pub actor: String,
@@ -43,9 +43,93 @@ pub struct PolicyCheckRequest {
     pub context: Option<serde_json::Value>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct PolicyCheckResponse {
     pub action: String,
     pub decision: String,
     pub reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_run_round_trip() {
+        let input =
+            r#"{"repo":"stevedores-org/data-fabric","trigger":"push","metadata":{"ref":"main"}}"#;
+        let parsed: CreateRun = serde_json::from_str(input).unwrap();
+        assert_eq!(parsed.repo, "stevedores-org/data-fabric");
+        assert_eq!(parsed.trigger.as_deref(), Some("push"));
+        let json = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CreateRun = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn create_run_minimal() {
+        let input = r#"{"repo":"my-repo"}"#;
+        let parsed: CreateRun = serde_json::from_str(input).unwrap();
+        assert_eq!(parsed.repo, "my-repo");
+        assert!(parsed.trigger.is_none());
+        assert!(parsed.metadata.is_none());
+    }
+
+    #[test]
+    fn run_created_serializes() {
+        let run = RunCreated {
+            id: "abc123".into(),
+            status: "created".into(),
+            repo: "test-repo".into(),
+        };
+        let json = serde_json::to_value(&run).unwrap();
+        assert_eq!(json["id"], "abc123");
+        assert_eq!(json["status"], "created");
+        assert_eq!(json["repo"], "test-repo");
+    }
+
+    #[test]
+    fn provenance_event_round_trip() {
+        let input =
+            r#"{"run_id":"r1","event_type":"build.start","actor":"ci-bot","payload":{"step":1}}"#;
+        let parsed: ProvenanceEvent = serde_json::from_str(input).unwrap();
+        assert_eq!(parsed.event_type, "build.start");
+        let json = serde_json::to_string(&parsed).unwrap();
+        let reparsed: ProvenanceEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn event_ack_serializes() {
+        let ack = EventAck {
+            id: "evt1".into(),
+            event_type: "build.start".into(),
+            accepted: true,
+        };
+        let json = serde_json::to_value(&ack).unwrap();
+        assert_eq!(json["accepted"], true);
+    }
+
+    #[test]
+    fn policy_check_round_trip() {
+        let input =
+            r#"{"action":"deploy","actor":"dev@example.com","resource":"prod","context":null}"#;
+        let parsed: PolicyCheckRequest = serde_json::from_str(input).unwrap();
+        assert_eq!(parsed.action, "deploy");
+        assert_eq!(parsed.resource.as_deref(), Some("prod"));
+        let json = serde_json::to_string(&parsed).unwrap();
+        let reparsed: PolicyCheckRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn policy_response_serializes() {
+        let resp = PolicyCheckResponse {
+            action: "deploy".into(),
+            decision: "allow".into(),
+            reason: "no restrictions".into(),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["decision"], "allow");
+    }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ account_id = "f1be33af27cf878e2e81cb29a0d886f7"
 workers_dev = true
 
 [build]
-command = "cargo install worker-build && worker-build --release"
+command = "worker-build --release"
 
 [vars]
 APP_ENV = "dev"


### PR DESCRIPTION
## Summary
- `generate_id()` now returns `Result` instead of unwrapping `getrandom` — proper error propagation
- All model structs derive `Debug`, `Serialize`, `Deserialize`, `PartialEq` for testing
- Added 7 serde round-trip tests covering all domain models (runs, events, policy)
- Removed `Cargo.lock` from `.gitignore` — lockfile should be committed for reproducible worker builds
- Added `/worker/generated` and `/.wrangler` to `.gitignore`
- Removed `cargo install worker-build` from wrangler build command (assumes pre-installed)

## Test plan
- [x] `cargo test` — 7/7 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)