### PR TITLE
ci: bootstrap GHA workflow on main for PR check discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [develop]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  local-ci:
+    name: local-ci (fmt, clippy, check, test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          components: rustfmt, clippy
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Install local-ci
+        run: go install github.com/stevedores-org/local-ci@latest
+
+      - name: Run local-ci
+        run: local-ci fmt clippy check test --no-cache --json


### PR DESCRIPTION
## Summary
- GitHub Actions requires workflows on the **default branch** (`main`) to trigger `pull_request` events
- Without this, PRs to `develop` never get CI checks (the workflow on `develop` only triggers `push` events)
- Includes fixes from PR #20 review: `setup-go` step, `test` stage in CI command

## Why main?
The `ci.yml` was merged to `develop` via PR #20, but PRs still had no checks because GitHub discovers workflows from `main`. This PR bootstraps the workflow on `main` so all future PRs get CI.

## Changes vs PR #20
- Added `actions/setup-go@v5` — ensures Go is available for `go install local-ci`
- Added `test` to the `local-ci` command — was missing, tests were not running in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)