### PR TITLE
fix(ci): add setup-go step and include test stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,12 @@ jobs:
           target: wasm32-unknown-unknown
           components: rustfmt, clippy
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
       - name: Install local-ci
         run: go install github.com/stevedores-org/local-ci@latest
 
       - name: Run local-ci
-        run: local-ci fmt clippy check --no-cache --json
+        run: local-ci fmt clippy check test --no-cache --json


### PR DESCRIPTION
## Summary
- Adds `actions/setup-go@v5` — ensures Go is reliably available for `go install local-ci`
- Adds `test` to the `local-ci` command — tests were not running in CI (missed in PR #20)

## Context
Fixes issues flagged in [PR #20 review](https://github.com/stevedores-org/data-fabric/pull/20#issuecomment-3941665822).
CI workflow also bootstrapped on `main` via PR #29 so `pull_request` triggers now work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)