### PR TITLE
fix: local-ci PATH in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
         run: go install github.com/stevedores-org/local-ci@latest
 
       - name: Run local-ci
-        run: local-ci fmt clippy check --no-cache --json
+        run: ~/go/bin/local-ci fmt clippy check --no-cache --json


### PR DESCRIPTION
## Summary
- `go install` puts binaries in `~/go/bin` which isn't in PATH on GHA runners
- Use full path `~/go/bin/local-ci` to fix `command not found` error
- This was blocking all PR checks (including #23, #24, #25)

## Test plan
- [ ] CI passes on this PR itself (self-validating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)