### PR TITLE
fix(ci): add setup-go and include test stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,12 @@ jobs:
           target: wasm32-unknown-unknown
           components: rustfmt, clippy
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
       - name: Install local-ci
         run: go install github.com/stevedores-org/local-ci@latest
 
       - name: Run local-ci
-        run: ~/go/bin/local-ci fmt clippy check --no-cache --json
+        run: local-ci fmt clippy check test --no-cache --json


### PR DESCRIPTION
## Summary
- Adds `actions/setup-go@v5` — ensures `go install` works and `GOPATH/bin` is on PATH
- Adds `test` to `local-ci` command — tests were not running in CI
- Removes `~/go/bin/` prefix hack — `setup-go` adds Go bin to PATH properly

## Context
CI was failing on all PRs with `local-ci: command not found` because `go install` needs Go on the runner and `GOPATH/bin` on `PATH`. The `~/go/bin/local-ci` workaround was a quick fix but `setup-go` is the correct approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)