### PR TITLE
feat(ws9): error envelope + cursor pagination on /v1/runs

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -600,29 +600,66 @@ pub async fn create_run(
     Ok(())
 }
 
+/// List runs for `tenant_id` ordered by `(created_at DESC, id DESC)`.
+///
+/// Returns `(rows, next_cursor)`. `next_cursor` is `Some` when there are more
+/// rows beyond this page — we fetch `limit + 1` and trim the overflow row to
+/// detect that without a second query.
+///
+/// The cursor predicate uses an OR of two terms (`created_at < ?` OR
+/// `created_at = ? AND id < ?`) rather than a row-value comparison because
+/// SQLite/D1 cannot index `(a, b) < (?, ?)` as a single sargable expression.
 pub async fn list_runs(
     db: &D1Database,
     tenant_id: &str,
     repo: Option<&str>,
     limit: u32,
-) -> Result<Vec<RunResponse>> {
-    let (query, bindings): (String, Vec<JsValue>) = match repo {
-        Some(r) => (
-            "SELECT * FROM runs WHERE tenant_id = ?1 AND repo = ?2 ORDER BY created_at DESC LIMIT ?3".into(),
-            vec![
-                JsValue::from_str(tenant_id),
-                JsValue::from_str(r),
-                JsValue::from(limit),
-            ],
-        ),
-        None => (
-            "SELECT * FROM runs WHERE tenant_id = ?1 ORDER BY created_at DESC LIMIT ?2".into(),
-            vec![JsValue::from_str(tenant_id), JsValue::from(limit)],
-        ),
-    };
+    cursor: Option<&crate::pagination::RunsCursor>,
+) -> Result<(Vec<RunResponse>, Option<crate::pagination::RunsCursor>)> {
+    let fetch_limit = limit.saturating_add(1);
+
+    // Build the predicate and bindings in lockstep so positional parameters
+    // stay in sync. Using `?` (positional, anonymous) instead of `?1/?2/...`
+    // because the parameter count depends on which optional filters are set.
+    let mut clauses: Vec<String> = vec!["tenant_id = ?".into()];
+    let mut bindings: Vec<JsValue> = vec![JsValue::from_str(tenant_id)];
+
+    if let Some(r) = repo {
+        clauses.push("repo = ?".into());
+        bindings.push(JsValue::from_str(r));
+    }
+    if let Some(c) = cursor {
+        clauses.push("(created_at < ? OR (created_at = ? AND id < ?))".into());
+        bindings.push(JsValue::from_str(&c.created_at));
+        bindings.push(JsValue::from_str(&c.created_at));
+        bindings.push(JsValue::from_str(&c.id));
+    }
+    bindings.push(JsValue::from(fetch_limit));
+
+    let query = format!(
+        "SELECT * FROM runs WHERE {} ORDER BY created_at DESC, id DESC LIMIT ?",
+        clauses.join(" AND ")
+    );
+
     let result: D1Result = db.prepare(&query).bind(&bindings)?.all().await?;
-    let rows: Vec<RunRow> = result.results()?;
-    Ok(rows.into_iter().map(|r| r.into_run_response()).collect())
+    let mut rows: Vec<RunRow> = result.results()?;
+
+    let next_cursor = if rows.len() as u32 > limit {
+        // Overflow row signals there's at least one more page. Drop it; the
+        // cursor is built from the *last returned* row, not the overflow.
+        rows.truncate(limit as usize);
+        rows.last().map(|r| crate::pagination::RunsCursor {
+            created_at: r.created_at.clone(),
+            id: r.id.clone(),
+        })
+    } else {
+        None
+    };
+
+    Ok((
+        rows.into_iter().map(|r| r.into_run_response()).collect(),
+        next_cursor,
+    ))
 }
 
 pub async fn get_run(db: &D1Database, tenant_id: &str, id: &str) -> Result<Option<RunResponse>> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,94 @@
+//! Structured error envelope returned by the fabric API.
+//!
+//! All error responses share this shape so SDK/CLI/operator tools can rely on
+//! a stable contract instead of parsing free-form text out of `Response::error`.
+//!
+//! ```json
+//! { "error": { "code": "RUN_NOT_FOUND", "message": "run not found" } }
+//! ```
+//!
+//! `code` is a stable, machine-readable identifier (SCREAMING_SNAKE_CASE).
+//! `message` is human-readable and may change. Populate `details` when callers
+//! need structured context (e.g. which fields failed validation).
+
+use serde::Serialize;
+use serde_json::Value;
+use worker::{Response, Result};
+
+#[derive(Serialize)]
+pub struct ErrorEnvelope<'a> {
+    pub code: &'a str,
+    pub message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    error: ErrorEnvelope<'a>,
+}
+
+/// Build a JSON error response with a stable `{ "error": { code, message } }`
+/// envelope and the given HTTP status.
+pub fn error_response(code: &str, message: &str, status: u16) -> Result<Response> {
+    let body = ErrorBody {
+        error: ErrorEnvelope {
+            code,
+            message,
+            details: None,
+        },
+    };
+    Ok(Response::from_json(&body)?.with_status(status))
+}
+
+/// Build a JSON error response that includes structured details.
+#[allow(dead_code)] // surface for future handlers (validation, conflict, etc.)
+pub fn error_response_with_details(
+    code: &str,
+    message: &str,
+    details: Value,
+    status: u16,
+) -> Result<Response> {
+    let body = ErrorBody {
+        error: ErrorEnvelope {
+            code,
+            message,
+            details: Some(details),
+        },
+    };
+    Ok(Response::from_json(&body)?.with_status(status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_serializes_with_stable_shape() {
+        let body = ErrorBody {
+            error: ErrorEnvelope {
+                code: "RUN_NOT_FOUND",
+                message: "run not found",
+                details: None,
+            },
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["error"]["code"], "RUN_NOT_FOUND");
+        assert_eq!(json["error"]["message"], "run not found");
+        assert!(json["error"].get("details").is_none());
+    }
+
+    #[test]
+    fn envelope_with_details_round_trips() {
+        let details = serde_json::json!({ "fields": ["repo"] });
+        let body = ErrorBody {
+            error: ErrorEnvelope {
+                code: "INVALID_REQUEST",
+                message: "missing required fields",
+                details: Some(details.clone()),
+            },
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(json["error"]["details"], details);
+    }
+}

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -580,7 +580,8 @@ pub mod mom {
             return String::new();
         }
 
-        let mut augmented = String::from("\n\n## Agent Memory Context (Relevant Past Experience)\n\n");
+        let mut augmented =
+            String::from("\n\n## Agent Memory Context (Relevant Past Experience)\n\n");
 
         for (i, mem) in memories.iter().enumerate() {
             augmented.push_str(&format!(
@@ -592,8 +593,10 @@ pub mod mom {
             ));
 
             if let Some(meta) = &mem.metadata {
-                augmented.push_str(&format!("   Details: {}\n", serde_json::to_string(meta)
-                    .unwrap_or_else(|_| "...".to_string())));
+                augmented.push_str(&format!(
+                    "   Details: {}\n",
+                    serde_json::to_string(meta).unwrap_or_else(|_| "...".to_string())
+                ));
             }
         }
 
@@ -644,7 +647,8 @@ pub mod mom {
 
             // Set Content-Type header
             let headers = worker::Headers::new();
-            headers.append("Content-Type", "application/json")
+            headers
+                .append("Content-Type", "application/json")
                 .map_err(|e| format!("Failed to set header: {:?}", e))?;
             opts.with_headers(headers);
 
@@ -660,7 +664,7 @@ pub mod mom {
                 Ok(mut response) => {
                     // Check response status code
                     let status = response.status_code();
-                    if status < 200 || status >= 300 {
+                    if !(200..300).contains(&status) {
                         // MOM returned error status - graceful degradation
                         return Ok(vec![]);
                     }
@@ -980,7 +984,8 @@ mod tests {
                 score: 0.87,
                 id: "mem-2".to_string(),
                 kind: "fact".to_string(),
-                content: "DashMap provides atomic entry mutation for lock-free patterns".to_string(),
+                content: "DashMap provides atomic entry mutation for lock-free patterns"
+                    .to_string(),
                 metadata: Some(serde_json::json!({"crate": "dashmap", "version": "5.x"})),
                 created_at_ms: 1609459200000,
                 importance: Some(0.7),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,10 @@ use serde::Serialize;
 use worker::*;
 
 mod db;
+mod errors;
 mod integrations;
 mod models;
+mod pagination;
 mod policy;
 mod storage;
 mod tenant;
@@ -57,7 +59,7 @@ async fn augment_task_with_memory(
         agent_id,
         tenant_id,
         &task_description,
-        None,  // workspace_id: task doesn't have it
+        None,    // workspace_id: task doesn't have it
         Some(5), // limit to top 5 memories
     );
 
@@ -136,14 +138,35 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect();
             let repo = params.get("repo").map(|s| s.as_str());
-            let limit = params
-                .get("limit")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(50u32)
-                .min(200);
+            let limit = pagination::clamp_limit(params.get("limit").and_then(|s| s.parse().ok()));
+            let cursor =
+                match pagination::RunsCursor::decode(params.get("cursor").map(|s| s.as_str())) {
+                    Ok(c) => c,
+                    Err(_) => {
+                        return errors::error_response(
+                            "INVALID_CURSOR",
+                            "cursor is malformed; echo back the next_cursor from a prior response",
+                            400,
+                        );
+                    }
+                };
             let d1 = ctx.env.d1("DB")?;
-            let runs = db::list_runs(&d1, &tenant_ctx.tenant_id, repo, limit).await?;
-            Response::from_json(&serde_json::json!({ "runs": runs }))
+            let (runs, next_cursor) =
+                db::list_runs(&d1, &tenant_ctx.tenant_id, repo, limit, cursor.as_ref()).await?;
+            let next_cursor_str = match next_cursor.as_ref().map(|c| c.encode()).transpose() {
+                Ok(s) => s,
+                Err(_) => {
+                    return errors::error_response(
+                        "CURSOR_ENCODE_FAILED",
+                        "internal: failed to encode next cursor",
+                        500,
+                    );
+                }
+            };
+            Response::from_json(&serde_json::json!({
+                "runs": runs,
+                "next_cursor": next_cursor_str,
+            }))
         })
         .get_async("/v1/runs/:id", |req, ctx| async move {
             let tenant_ctx = tenant::tenant_from_request(&req)?;
@@ -151,7 +174,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
             let d1 = ctx.env.d1("DB")?;
             match db::get_run(&d1, &tenant_ctx.tenant_id, &id).await? {
                 Some(run) => Response::from_json(&run),
-                None => Response::error("run not found", 404),
+                None => errors::error_response("RUN_NOT_FOUND", "run not found", 404),
             }
         })
         // ── WS2 Tasks (run-scoped, D1-backed) ───────────────
@@ -564,11 +587,17 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                     // This allows agents to reason with past experience
                     let mom_endpoint = ctx.env.var("MOM_ENDPOINT").ok().map(|v| v.to_string());
                     if let Some(endpoint) = mom_endpoint {
-                        let memory_context = augment_task_with_memory(&agent_id, &tenant_ctx.tenant_id, &task, &endpoint).await;
+                        let memory_context = augment_task_with_memory(
+                            &agent_id,
+                            &tenant_ctx.tenant_id,
+                            &task,
+                            &endpoint,
+                        )
+                        .await;
                         task.memory_context = memory_context;
                     }
                     Response::from_json(&task)
-                },
+                }
                 None => Ok(Response::empty()?.with_status(204)),
             }
         })

--- a/src/models/tests.rs
+++ b/src/models/tests.rs
@@ -1032,7 +1032,8 @@ fn run_summary_actors_and_event_types_deduplication() {
     let actors = json["actors"].as_array().unwrap();
     assert_eq!(actors.len(), 2);
     // Verify no duplicates in serialized form
-    let unique: std::collections::HashSet<&str> = actors.iter().map(|a| a.as_str().unwrap()).collect();
+    let unique: std::collections::HashSet<&str> =
+        actors.iter().map(|a| a.as_str().unwrap()).collect();
     assert_eq!(unique.len(), actors.len());
 }
 
@@ -1082,10 +1083,46 @@ fn task_dependency_edge_with_full_causality_chain() {
 fn provenance_edge_full_causality_chain_round_trip() {
     // Full chain: run → plan → task → tool_call → artifact
     let chain = vec![
-        ProvenanceEdge { depth: 0, rel_type: "causality".into(), from_kind: "run".into(), from_id: "r1".into(), to_kind: "plan".into(), to_id: "p1".into(), relation: Some("planned".into()), created_at: Some("2026-01-01T00:00:00Z".into()) },
-        ProvenanceEdge { depth: 1, rel_type: "causality".into(), from_kind: "plan".into(), from_id: "p1".into(), to_kind: "task".into(), to_id: "t1".into(), relation: Some("scheduled".into()), created_at: Some("2026-01-01T00:00:01Z".into()) },
-        ProvenanceEdge { depth: 2, rel_type: "causality".into(), from_kind: "task".into(), from_id: "t1".into(), to_kind: "tool_call".into(), to_id: "tc1".into(), relation: Some("invoked".into()), created_at: Some("2026-01-01T00:00:02Z".into()) },
-        ProvenanceEdge { depth: 3, rel_type: "causality".into(), from_kind: "tool_call".into(), from_id: "tc1".into(), to_kind: "artifact".into(), to_id: "a1".into(), relation: Some("produced".into()), created_at: Some("2026-01-01T00:00:03Z".into()) },
+        ProvenanceEdge {
+            depth: 0,
+            rel_type: "causality".into(),
+            from_kind: "run".into(),
+            from_id: "r1".into(),
+            to_kind: "plan".into(),
+            to_id: "p1".into(),
+            relation: Some("planned".into()),
+            created_at: Some("2026-01-01T00:00:00Z".into()),
+        },
+        ProvenanceEdge {
+            depth: 1,
+            rel_type: "causality".into(),
+            from_kind: "plan".into(),
+            from_id: "p1".into(),
+            to_kind: "task".into(),
+            to_id: "t1".into(),
+            relation: Some("scheduled".into()),
+            created_at: Some("2026-01-01T00:00:01Z".into()),
+        },
+        ProvenanceEdge {
+            depth: 2,
+            rel_type: "causality".into(),
+            from_kind: "task".into(),
+            from_id: "t1".into(),
+            to_kind: "tool_call".into(),
+            to_id: "tc1".into(),
+            relation: Some("invoked".into()),
+            created_at: Some("2026-01-01T00:00:02Z".into()),
+        },
+        ProvenanceEdge {
+            depth: 3,
+            rel_type: "causality".into(),
+            from_kind: "tool_call".into(),
+            from_id: "tc1".into(),
+            to_kind: "artifact".into(),
+            to_id: "a1".into(),
+            relation: Some("produced".into()),
+            created_at: Some("2026-01-01T00:00:03Z".into()),
+        },
     ];
     let json = serde_json::to_string(&chain).unwrap();
     let parsed: Vec<ProvenanceEdge> = serde_json::from_str(&json).unwrap();
@@ -1107,9 +1144,16 @@ fn provenance_response_with_hops_parameter() {
         entity_id: "r1".into(),
         direction: "forward".into(),
         hops: 5,
-        edges: vec![
-            ProvenanceEdge { depth: 0, rel_type: "causality".into(), from_kind: "run".into(), from_id: "r1".into(), to_kind: "plan".into(), to_id: "p1".into(), relation: Some("planned".into()), created_at: None },
-        ],
+        edges: vec![ProvenanceEdge {
+            depth: 0,
+            rel_type: "causality".into(),
+            from_kind: "run".into(),
+            from_id: "r1".into(),
+            to_kind: "plan".into(),
+            to_id: "p1".into(),
+            relation: Some("planned".into()),
+            created_at: None,
+        }],
     };
     let json = serde_json::to_value(&resp).unwrap();
     assert_eq!(json["hops"], 5);
@@ -1125,8 +1169,26 @@ fn provenance_response_backward_direction() {
         direction: "backward".into(),
         hops: 3,
         edges: vec![
-            ProvenanceEdge { depth: 0, rel_type: "causality".into(), from_kind: "tool_call".into(), from_id: "tc1".into(), to_kind: "artifact".into(), to_id: "a1".into(), relation: Some("produced".into()), created_at: None },
-            ProvenanceEdge { depth: 1, rel_type: "causality".into(), from_kind: "task".into(), from_id: "t1".into(), to_kind: "tool_call".into(), to_id: "tc1".into(), relation: Some("invoked".into()), created_at: None },
+            ProvenanceEdge {
+                depth: 0,
+                rel_type: "causality".into(),
+                from_kind: "tool_call".into(),
+                from_id: "tc1".into(),
+                to_kind: "artifact".into(),
+                to_id: "a1".into(),
+                relation: Some("produced".into()),
+                created_at: None,
+            },
+            ProvenanceEdge {
+                depth: 1,
+                rel_type: "causality".into(),
+                from_kind: "task".into(),
+                from_id: "t1".into(),
+                to_kind: "tool_call".into(),
+                to_id: "tc1".into(),
+                relation: Some("invoked".into()),
+                created_at: None,
+            },
         ],
     };
     let json = serde_json::to_string(&resp).unwrap();
@@ -1142,8 +1204,18 @@ fn replay_plan_response_planned_status() {
     let resp = ReplayPlanResponse {
         run_id: "r1".into(),
         steps: vec![
-            ReplayStep { sequence: 1, event_type: "run.start".into(), node_id: None, actor: Some("ci".into()) },
-            ReplayStep { sequence: 2, event_type: "task.start".into(), node_id: Some("n1".into()), actor: Some("agent".into()) },
+            ReplayStep {
+                sequence: 1,
+                event_type: "run.start".into(),
+                node_id: None,
+                actor: Some("ci".into()),
+            },
+            ReplayStep {
+                sequence: 2,
+                event_type: "task.start".into(),
+                node_id: Some("n1".into()),
+                actor: Some("agent".into()),
+            },
         ],
         status: "planned".into(),
     };
@@ -1213,7 +1285,10 @@ fn replay_execute_response_needs_review_status() {
     assert!(!json["within_variance"].as_bool().unwrap());
     assert_eq!(json["failure_classification"], "logical");
     assert_eq!(json["verification"]["confidence_score"], 75);
-    assert_eq!(json["verification"]["failed_gates"][0], "provenance_complete");
+    assert_eq!(
+        json["verification"]["failed_gates"][0],
+        "provenance_complete"
+    );
 }
 
 // ── Phase 4: Memory-Augmented Tasks (WS6) ────────────────────────
@@ -1267,7 +1342,9 @@ fn agent_task_with_memory_context_some() {
         lease_expires_at: None,
         created_at: "2026-01-01T00:00:00Z".into(),
         completed_at: None,
-        memory_context: Some("## Memory: Past Experience\n- Fixed similar build issue with cargo cache".into()),
+        memory_context: Some(
+            "## Memory: Past Experience\n- Fixed similar build issue with cargo cache".into(),
+        ),
     };
     let json = serde_json::to_string(&task).unwrap();
     let parsed: AgentTask = serde_json::from_str(&json).unwrap();
@@ -1299,7 +1376,9 @@ fn agent_task_memory_context_round_trip() {
         lease_expires_at: None,
         created_at: "2026-01-01T00:00:00Z".into(),
         completed_at: None,
-        memory_context: Some("## Memory Context\nPrevious analysis on similar codebase. Use AST traversal.".into()),
+        memory_context: Some(
+            "## Memory Context\nPrevious analysis on similar codebase. Use AST traversal.".into(),
+        ),
     };
     let json = serde_json::to_string(&task).unwrap();
     let parsed: AgentTask = serde_json::from_str(&json).unwrap();

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -1,0 +1,99 @@
+//! Opaque cursor-based pagination for list endpoints.
+//!
+//! A cursor is the hex-encoded JSON of the last seen row's sort key. The shape
+//! is intentionally opaque to clients — they must echo back whatever
+//! `next_cursor` we returned without parsing it. Hex keeps the cursor
+//! URL-safe and doesn't need a new crate dependency (`hex` is already pulled in
+//! for IDs).
+//!
+//! For `/v1/runs` the sort key is `(created_at DESC, id DESC)`, so the cursor
+//! carries both fields. Including `id` breaks ties when two runs share the
+//! same `created_at`.
+
+use serde::{Deserialize, Serialize};
+use worker::Result;
+
+/// Sort-key tuple for `/v1/runs` pagination.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunsCursor {
+    /// Last row's `created_at` (ISO 8601 string from D1).
+    #[serde(rename = "c")]
+    pub created_at: String,
+    /// Last row's `id`, used as a tiebreaker for rows sharing `created_at`.
+    #[serde(rename = "i")]
+    pub id: String,
+}
+
+impl RunsCursor {
+    /// Encode the cursor as a hex string suitable for `?cursor=` query params.
+    pub fn encode(&self) -> Result<String> {
+        let json = serde_json::to_vec(self)
+            .map_err(|e| worker::Error::RustError(format!("encode cursor: {e}")))?;
+        Ok(hex::encode(json))
+    }
+
+    /// Decode a hex-encoded cursor. Returns `Ok(None)` if the input is empty,
+    /// `Err` if the input is present but malformed (callers should map this
+    /// to `INVALID_CURSOR` 400).
+    pub fn decode(raw: Option<&str>) -> Result<Option<Self>> {
+        let Some(raw) = raw.filter(|s| !s.is_empty()) else {
+            return Ok(None);
+        };
+        let bytes = hex::decode(raw)
+            .map_err(|e| worker::Error::RustError(format!("decode cursor hex: {e}")))?;
+        let cursor: Self = serde_json::from_slice(&bytes)
+            .map_err(|e| worker::Error::RustError(format!("decode cursor json: {e}")))?;
+        Ok(Some(cursor))
+    }
+}
+
+/// Clamp a client-supplied `?limit=` to the documented bounds.
+///
+/// Default 50, hard max 200 — matches what the existing handler already did
+/// before pagination was added, so behavior is unchanged for callers that
+/// don't send `?cursor=`.
+pub const DEFAULT_PAGE_LIMIT: u32 = 50;
+pub const MAX_PAGE_LIMIT: u32 = 200;
+
+pub fn clamp_limit(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_roundtrips_through_hex() {
+        let cursor = RunsCursor {
+            created_at: "2026-05-13T10:00:00Z".into(),
+            id: "abc123".into(),
+        };
+        let encoded = cursor.encode().expect("encode");
+        let decoded = RunsCursor::decode(Some(&encoded))
+            .expect("decode")
+            .expect("some");
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn decode_returns_none_for_absent_or_empty() {
+        assert!(RunsCursor::decode(None).unwrap().is_none());
+        assert!(RunsCursor::decode(Some("")).unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_errors_on_garbage() {
+        assert!(RunsCursor::decode(Some("not-hex-zzzz")).is_err());
+        // Valid hex but not JSON
+        assert!(RunsCursor::decode(Some("deadbeef")).is_err());
+    }
+
+    #[test]
+    fn clamp_limit_applies_defaults_and_caps() {
+        assert_eq!(clamp_limit(None), DEFAULT_PAGE_LIMIT);
+        assert_eq!(clamp_limit(Some(10)), 10);
+        assert_eq!(clamp_limit(Some(0)), 1);
+        assert_eq!(clamp_limit(Some(5_000)), MAX_PAGE_LIMIT);
+    }
+}

--- a/src/tenant_security.rs
+++ b/src/tenant_security.rs
@@ -197,20 +197,14 @@ pub struct TokenClaims {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthzError {
     /// The action is not permitted for this role.
-    PermissionDenied {
-        role: Role,
-        required: Permission,
-    },
+    PermissionDenied { role: Role, required: Permission },
     /// Attempted cross-tenant resource access.
     CrossTenantAccess {
         requesting_tenant: String,
         resource_tenant: String,
     },
     /// Rate limit exceeded.
-    RateLimitExceeded {
-        tenant_id: String,
-        limit: u64,
-    },
+    RateLimitExceeded { tenant_id: String, limit: u64 },
 }
 
 impl fmt::Display for AuthzError {
@@ -255,10 +249,8 @@ pub fn evaluate_authz(
     // 2. Permission check — prefer token-scoped overrides, else policy.
     let effective = match &claims.scoped_permissions {
         Some(scoped) => scoped.clone(),
-        None => AuthzPolicy::default().permissions_for_role_resource(
-            &claims.role,
-            &resource.resource_type,
-        ),
+        None => AuthzPolicy::default()
+            .permissions_for_role_resource(&claims.role, &resource.resource_type),
     };
 
     if effective.contains(&action) {
@@ -480,9 +472,7 @@ pub fn classify_field(field_name: &str) -> SecretClassification {
 /// Returns `Ok(())` if all fields classified as Restricted or Confidential
 /// have placeholder/encrypted values (i.e., start with `"enc:"` or `"***"`).
 /// Otherwise returns `Err` with the offending field names.
-pub fn validate_no_plaintext_secrets(
-    record: &serde_json::Value,
-) -> Result<(), Vec<String>> {
+pub fn validate_no_plaintext_secrets(record: &serde_json::Value) -> Result<(), Vec<String>> {
     let mut violations = Vec::new();
 
     if let Some(obj) = record.as_object() {
@@ -543,8 +533,7 @@ pub fn redact_sensitive_fields(record: &serde_json::Value) -> serde_json::Value 
 // ── 5. Cross-Tenant Federation ─────────────────────────────────────
 
 /// Configuration for cross-tenant data sharing.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FederationConfig {
     /// Whether this tenant has opted into federation.
     pub opt_in: bool,
@@ -553,7 +542,6 @@ pub struct FederationConfig {
     /// Types of data that may be shared.
     pub sharing_scope: HashSet<String>,
 }
-
 
 /// Check whether federation is allowed between two tenants for a given
 /// data type.

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -183,12 +183,32 @@ mod tests {
     #[test]
     fn compute_replay_drift_percent_full_mismatch() {
         let replay = vec![
-            models::ReplayStep { sequence: 1, event_type: "a".into(), node_id: None, actor: None },
-            models::ReplayStep { sequence: 2, event_type: "b".into(), node_id: None, actor: None },
+            models::ReplayStep {
+                sequence: 1,
+                event_type: "a".into(),
+                node_id: None,
+                actor: None,
+            },
+            models::ReplayStep {
+                sequence: 2,
+                event_type: "b".into(),
+                node_id: None,
+                actor: None,
+            },
         ];
         let baseline = vec![
-            models::ReplayStep { sequence: 1, event_type: "x".into(), node_id: None, actor: None },
-            models::ReplayStep { sequence: 2, event_type: "y".into(), node_id: None, actor: None },
+            models::ReplayStep {
+                sequence: 1,
+                event_type: "x".into(),
+                node_id: None,
+                actor: None,
+            },
+            models::ReplayStep {
+                sequence: 2,
+                event_type: "y".into(),
+                node_id: None,
+                actor: None,
+            },
         ];
         let (drift_count, drift_ratio) = compute_replay_drift_percent(&replay, &baseline);
         assert_eq!(drift_count, 2);


### PR DESCRIPTION
## Summary

First slice of #49 (WS9: Developer UX & APIs). Lands the two contracts the rest of WS9 — SDK, CLI, OpenAPI spec — needs to anchor on, in a narrow PR:

- **Structured error envelope** (`src/errors.rs`) — `{ "error": { code, message, details? } }` with stable SCREAMING_SNAKE_CASE codes. Retrofitted to the `/v1/runs` surface only; other ~50 sites migrate incrementally as SDK/docs work touches them.
- **Cursor pagination on `GET /v1/runs`** (`src/pagination.rs`) — opaque hex(JSON) cursor over `(created_at DESC, id DESC)`. `db::list_runs` fetches `limit + 1`, trims the overflow, emits `next_cursor` from the last returned row.

## Response shape change (additive)

`GET /v1/runs` now returns `{ runs, next_cursor }`. `next_cursor` is `null` on the last page. Existing clients ignoring the new field keep working.

## Two commits

1. `chore: rustfmt + apply clippy::manual_range_contains` — pre-existing develop debt surfaced by the WS9 work. Pure mechanical, no logic changes.
2. `feat(ws9): structured error envelope + cursor pagination on /v1/runs` — the actual feature.

Split for reviewer clarity; reviewers can skip the first commit.

## Design notes

- **Cursor predicate** uses `created_at < ? OR (created_at = ? AND id < ?)` instead of `(created_at, id) < (?, ?)`. SQLite/D1 can index the OR form against `(tenant_id, created_at, id)`; the row-value form is not sargable.
- **Hex encoding** for the cursor rather than base64 — `hex` is already a workspace dependency for IDs, no new crate needed. Cursor is URL-safe by construction.
- **Default 50, max 200** matches the previous hand-rolled clamp — no behavior change for callers that don't send `?cursor=`.

## Test plan

- [x] `cargo test --lib`: 247 passed (was 241; 6 new tests for envelope and cursor)
- [x] `cargo clippy --lib --tests -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [ ] After merge: manual `curl /v1/runs?limit=10` to confirm `next_cursor` round-trips
- [ ] After merge: confirm `/v1/runs/:id` 404 now returns JSON envelope, not text

Refs #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)