### PR TITLE
docs: establish ADR framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ cargo test
 - `docs/CONTRIBUTING_WORKFLOW.md`
 - `docs/TDD-MIGRATION-NODE-NPM-TO-BUN-BUNX.md`
 - `docs/TDD-BUN-BUNX-EXECUTION-PLAN.md`
+- `docs/adr/README.md`
 - `docs/ws1/README.md`
 - `docs/WS5_RETRIEVAL_MEMORY.md`
 - `docs/WS4_POLICY_GOVERNANCE.md`

--- a/docs/MISSION_PLAN.md
+++ b/docs/MISSION_PLAN.md
@@ -45,6 +45,11 @@
 - memory lifecycle retirement + GC
 - retrieval feedback and evaluation metrics
 
+## Architecture Decision Records
+- ADR framework established in `docs/adr/README.md`
+- decision backlog tracked in `docs/adr/BACKLOG.md`
+- initial accepted ADRs cover event ordering, policy placement, and memory index backend
+
 ## Immediate Next Tasks
 1. ~~Add D1 schema migration for silver entities.~~ (done: `migrations/0001_silver_entities.sql`, D1 binding in wrangler)
 2. ~~Add R2 artifact write/read path.~~ (done: PUT/GET `/v1/artifacts/:key` use R2 binding)

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,40 @@
+# ADR-NNNN: Title
+
+Status: proposed
+Date: YYYY-MM-DD
+Issue: #NNNN
+Workstream: WSx
+
+## Context
+
+Describe the decision pressure, affected systems, constraints, and why the
+decision is needed now.
+
+## Options
+
+| Option | Summary | Impact | Risk | Complexity | Reversibility |
+| --- | --- | ---: | ---: | ---: | ---: |
+| A |  |  |  |  |  |
+| B |  |  |  |  |  |
+| C |  |  |  |  |  |
+
+## Evidence
+
+- Evidence item 1.
+- Evidence item 2.
+
+## Decision
+
+State the selected option and the concrete implementation boundary.
+
+## Consequences
+
+- Positive consequence.
+- Tradeoff or limitation.
+- Follow-up work.
+
+## Rollback Plan
+
+Explain how to reverse or supersede the decision, including data migration or
+compatibility steps if needed.
+

--- a/docs/adr/0001-event-ordering-strategy.md
+++ b/docs/adr/0001-event-ordering-strategy.md
@@ -1,0 +1,48 @@
+# ADR-0001: Event Ordering Strategy
+
+Status: accepted
+Date: 2026-05-19
+Issue: #51
+Workstream: WS3
+
+## Context
+
+WS3 provenance needs stable ordering across Worker requests, D1 writes, queue
+consumers, and integration adapters. The ordering strategy must preserve enough
+causality for trace reconstruction without forcing every producer to coordinate
+through a single clock authority.
+
+## Options
+
+| Option | Summary | Impact | Risk | Complexity | Reversibility |
+| --- | --- | ---: | ---: | ---: | ---: |
+| A | Wall-clock timestamps only | 2 | 2 | 1 | 5 |
+| B | Hybrid Logical Clocks (HLC) | 5 | 3 | 3 | 4 |
+| C | Vector clocks per actor | 5 | 4 | 5 | 2 |
+
+## Evidence
+
+- Current event and provenance models already carry timestamps and actor/run
+  identity, so HLC can be added without replacing the whole event schema.
+- Vector clocks give richer causality but add payload size and merge complexity
+  for every integration producer.
+
+## Decision
+
+Use Hybrid Logical Clocks for canonical event ordering. Persist HLC fields
+alongside existing event timestamps where strict replay ordering is required.
+Use wall-clock timestamps for display and analytics only.
+
+## Consequences
+
+- Trace reconstruction can order concurrent events deterministically.
+- Producers need a small HLC helper but do not need full vector-clock state.
+- Cross-system adapters can degrade to wall-clock plus sequence number until
+  they support HLC metadata.
+
+## Rollback Plan
+
+If HLC proves insufficient, add vector-clock metadata as an optional extension
+without removing existing HLC columns. Consumers should treat unknown causality
+fields as advisory until a superseding ADR changes the canonical contract.
+

--- a/docs/adr/0002-policy-engine-placement.md
+++ b/docs/adr/0002-policy-engine-placement.md
@@ -1,0 +1,46 @@
+# ADR-0002: Policy Engine Placement
+
+Status: accepted
+Date: 2026-05-19
+Issue: #51
+Workstream: WS4
+
+## Context
+
+WS4 policy checks sit on the request path for autonomous agents. The first
+implementation needs low latency, tenant-aware decisions, and simple deployment
+inside the Cloudflare Worker. The alternative is an external policy engine such
+as OPA, which increases expressiveness but adds network and operational cost.
+
+## Options
+
+| Option | Summary | Impact | Risk | Complexity | Reversibility |
+| --- | --- | ---: | ---: | ---: | ---: |
+| A | In-worker Rust policy evaluator | 5 | 2 | 3 | 4 |
+| B | External OPA service | 4 | 4 | 4 | 3 |
+| C | Static allow/deny configuration only | 2 | 3 | 1 | 5 |
+
+## Evidence
+
+- Current policy code and tests already cover risk classification, wildcard
+  matching, rate limits, and tenant authorization in-process.
+- Worker-local policy checks avoid a network hop on every agent action.
+
+## Decision
+
+Keep policy evaluation in the Worker for the initial control plane. Store policy
+definitions in data-fabric storage, evaluate them in Rust, and persist decisions
+for audit and replay.
+
+## Consequences
+
+- Policy checks remain fast and deploy with the Worker.
+- Policy language stays narrower than OPA/Rego until there is concrete demand.
+- Future OPA integration should be adapter-based rather than a hard dependency.
+
+## Rollback Plan
+
+If in-worker policy becomes too limited, introduce an external evaluator behind
+the same `/v1/policies/check` contract. Keep the Rust evaluator as fallback for
+degraded mode and migrate policy definitions through a compatibility adapter.
+

--- a/docs/adr/0003-memory-index-backend.md
+++ b/docs/adr/0003-memory-index-backend.md
@@ -1,0 +1,47 @@
+# ADR-0003: Memory Index Backend
+
+Status: accepted
+Date: 2026-05-19
+Issue: #51
+Workstream: WS5
+
+## Context
+
+WS5 retrieval and memory federation need a default index that works in the
+Cloudflare-native deployment while still allowing deeper retrieval integrations
+for graph or vector-heavy workloads.
+
+## Options
+
+| Option | Summary | Impact | Risk | Complexity | Reversibility |
+| --- | --- | ---: | ---: | ---: | ---: |
+| A | D1 FTS as the default index | 4 | 2 | 2 | 4 |
+| B | External vector database as the default | 5 | 4 | 4 | 3 |
+| C | Adapter-only, no built-in index | 3 | 3 | 2 | 5 |
+
+## Evidence
+
+- The architecture already maps metadata and indexes to D1, with optional deep
+  retrieval adapters for more complex graph reasoning.
+- A built-in D1 path keeps local development and tenant bootstrap simple.
+
+## Decision
+
+Use D1 FTS as the default memory index for first-party retrieval. Keep the
+adapter boundary open for external vector or graph backends when a workload
+needs deeper semantic retrieval than D1 FTS can provide.
+
+## Consequences
+
+- The default deployment remains Cloudflare-native and low-ops.
+- Retrieval quality is bounded by D1 FTS until adapter-backed semantic retrieval
+  is configured.
+- WS5 should document when to route a query to an external retrieval adapter.
+
+## Rollback Plan
+
+If D1 FTS is not sufficient for pilot workloads, promote the external retrieval
+adapter to the default path while retaining D1 FTS as a metadata and fallback
+index. Existing memory rows remain valid because the index backend is an
+implementation detail behind the retrieval API.
+

--- a/docs/adr/BACKLOG.md
+++ b/docs/adr/BACKLOG.md
@@ -1,0 +1,18 @@
+# ADR Backlog
+
+This backlog tracks workstream-blocking architecture decisions from #51.
+
+| Priority | Decision | Workstream | Owner | Target ADR | Status |
+| --- | --- | --- | --- | --- | --- |
+| High | Event ordering strategy (HLC vs vector clocks) | WS3 | architecture review | [0001](0001-event-ordering-strategy.md) | accepted |
+| High | Policy engine placement (in-worker vs external OPA) | WS4 | architecture review | [0002](0002-policy-engine-placement.md) | accepted |
+| Medium | Memory index backend (D1 FTS vs external) | WS5 | architecture review | [0003](0003-memory-index-backend.md) | accepted |
+| Medium | Tenant isolation model (row-level vs schema-level) | WS8 | unassigned | TBD | proposed |
+| Low | SDK language priorities (Rust-first vs polyglot) | WS9 | unassigned | TBD | proposed |
+
+## Review Cadence
+
+- Weekly architecture review handles high-risk or workstream-blocking ADRs.
+- Low-risk ADRs can be accepted asynchronously through PR review.
+- Any accepted ADR can be superseded by a later ADR when measurements change.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,50 @@
+# Architecture Decision Records
+
+This directory stores data-fabric architecture decision records (ADRs).
+ADRs are lightweight, durable records for decisions that affect runtime
+architecture, data contracts, operational posture, or cross-repo integration.
+
+## Decision Flow
+
+1. Add a proposal from `0000-template.md` using the next sequence number.
+2. Fill in context, options, scoring, decision, consequences, and rollback plan.
+3. Mark the ADR `proposed` while review is active.
+4. Move to `accepted`, `rejected`, or `superseded` after review.
+5. Link the ADR from `BACKLOG.md` and any related issue or PR.
+
+Low-risk decisions can be reviewed asynchronously in a PR. Workstream-blocking
+or high-risk decisions should be reviewed in the weekly architecture review.
+
+## Scoring
+
+Score each option from 1 to 5:
+
+| Dimension | 1 | 5 |
+| --- | --- | --- |
+| Impact | Small/local effect | Major velocity or platform effect |
+| Risk | Low blast radius | High blast radius or hard to validate |
+| Complexity | Simple implementation | Multi-system or novel implementation |
+| Reversibility | Easy rollback | Hard migration or durable data impact |
+
+Prefer options with high impact, manageable risk, low complexity, and high
+reversibility. When a high-risk option is selected, the rollback plan must be
+explicit enough to execute without redesign.
+
+## Evidence Bar
+
+Every accepted ADR should cite at least one concrete evidence source:
+
+- benchmark or measurement
+- prototype or integration test
+- prior production behavior from data-fabric or an integration repo
+- compatibility analysis against current D1/R2/Worker constraints
+- operational rollback or migration rehearsal
+
+## Current ADRs
+
+| ADR | Status | Decision |
+| --- | --- | --- |
+| [0001](0001-event-ordering-strategy.md) | accepted | Use Hybrid Logical Clocks for event ordering |
+| [0002](0002-policy-engine-placement.md) | accepted | Keep policy evaluation in-worker for the initial control plane |
+| [0003](0003-memory-index-backend.md) | accepted | Start with D1 FTS plus optional external retrieval adapters |
+


### PR DESCRIPTION
Closes #51.

## Summary

Adds the ADR framework requested by #51:

- `docs/adr/README.md` with decision flow, scoring dimensions, evidence bar, and review cadence
- `docs/adr/0000-template.md` for future decisions
- `docs/adr/BACKLOG.md` tracking the initial decision backlog from #51
- three accepted ADRs for the first workstream-blocking decisions:
  - ADR-0001: Event ordering strategy
  - ADR-0002: Policy engine placement
  - ADR-0003: Memory index backend
- links the ADR docs from `README.md` and `docs/MISSION_PLAN.md`

## Verification

- [x] `cargo fmt --check`