### PR TITLE
feat(repo): shared D1/R2 repository abstraction with typed errors + retry (closes #53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-fabric-repo"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "thiserror",
+ "worker",
+]
+
+[[package]]
 name = "data-fabric-worker"
 version = "0.1.0"
 dependencies = [
@@ -551,6 +560,26 @@ name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/stevedores-org/data-fabric"
 description = "Cloudflare-native data fabric for autonomous AI agent builder orchestration"
 
 [workspace]
-members = ["xtask"]
+members = ["xtask", "data-fabric-repo"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/data-fabric-repo/Cargo.toml
+++ b/data-fabric-repo/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "data-fabric-repo"
+version = "0.1.0"
+edition = "2021"
+authors = ["Stevedores Org"]
+license = "Apache-2.0"
+repository = "https://github.com/stevedores-org/data-fabric"
+description = "Shared D1/R2 repository abstraction, typed error taxonomy, and retry policy for the data-fabric worker (WS1B / issue #53)."
+
+# This crate is a library used inside the Workers wasm runtime. It must
+# compile to `wasm32-unknown-unknown` and must not pull in std-net/native
+# random sources. See `src/retry.rs` for the rand-free jitter rationale.
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+# Same major.minor as the root worker crate so types line up across the
+# workspace. `d1` enables the `D1Database` type used by `D1Repository`.
+worker = { version = "0.8.1", features = ["d1"] }
+async-trait = "0.1"
+thiserror = "1"
+
+[dev-dependencies]
+# Unit tests for status-code mapping, retry attempt counting, and backoff
+# bounds are pure-Rust and don't need wasm. They run on the host target via
+# `cargo test -p data-fabric-repo`.

--- a/data-fabric-repo/src/d1.rs
+++ b/data-fabric-repo/src/d1.rs
@@ -1,0 +1,154 @@
+//! [`D1Repository`] — generic [`Repository`] adapter over `worker::D1Database`.
+//!
+//! ## Scope of this adapter
+//!
+//! The existing `src/db.rs` runs ~30 hand-rolled queries. Migrating each
+//! one is out of scope for this PR (issue #53 explicitly carves that out
+//! as a follow-up). What this adapter establishes is the *shape* the
+//! migration will land on:
+//!
+//! - construction takes a borrowed `&D1Database` so we don't double-own the
+//!   binding the worker request handler already holds;
+//! - the SQL strings (`select_sql`, `upsert_sql`, `delete_sql`) are passed
+//!   in by the caller, so each domain repo (RunsRepo, TasksRepo, …) is a
+//!   thin wrapper that supplies its own table-specific SQL + row decoder;
+//! - errors round-trip through [`Error::from(worker::Error)`] so the retry
+//!   helper can classify D1 busy / locked failures.
+//!
+//! We deliberately don't try to be sqlx — generating SQL is out of scope.
+//! The point is to have one place that handles error mapping + health
+//! probing + retry hooks.
+
+use async_trait::async_trait;
+use worker::wasm_bindgen::JsValue;
+use worker::D1Database;
+
+use crate::error::Error;
+use crate::repository::Repository;
+
+/// Decode a single D1 row into a domain `Value`. Each domain repo provides
+/// its own decoder closure so we can stay generic without baking
+/// `serde::Deserialize` into the trait surface.
+pub type RowDecoder<V> = Box<dyn Fn(&worker::D1Result) -> Result<Option<V>, Error>>;
+
+/// Generic D1 row repository.
+///
+/// Borrowed handle (`&'a D1Database`) — we **don't** clone the binding
+/// because that would defeat the purpose of having a single resolved
+/// binding per request. Lifetime `'a` ties the repo to the request scope.
+pub struct D1Repository<'a, V> {
+    db: &'a D1Database,
+    select_sql: &'static str,
+    upsert_sql: &'static str,
+    delete_sql: &'static str,
+    decode: RowDecoder<V>,
+}
+
+impl<'a, V> D1Repository<'a, V> {
+    /// Build a D1-backed repo.
+    ///
+    /// SQL strings are `&'static str` because every domain repo statically
+    /// owns its queries; this also matches D1's expectation that callers
+    /// re-use prepared statements where possible.
+    pub fn new(
+        db: &'a D1Database,
+        select_sql: &'static str,
+        upsert_sql: &'static str,
+        delete_sql: &'static str,
+        decode: RowDecoder<V>,
+    ) -> Self {
+        Self {
+            db,
+            select_sql,
+            upsert_sql,
+            delete_sql,
+            decode,
+        }
+    }
+
+    /// Borrow the underlying D1 binding. Escape hatch for queries that
+    /// don't fit the point-CRUD shape (lists, joins, batch writes). The
+    /// existing `src/db.rs` will keep calling into this for the foreseeable
+    /// future; this method makes the abstraction additive rather than
+    /// exclusive.
+    pub fn db(&self) -> &D1Database {
+        self.db
+    }
+}
+
+/// Implementation note: `put` here is *not* expected to be used with the
+/// trait alone for most of our writes — the existing call sites bind 8-12
+/// parameters per insert. The trait's `put(key, value) -> ()` shape is a
+/// least-common-denominator that covers blob-shaped writes (e.g. a
+/// serialized JSON snapshot keyed by id). For multi-column inserts the
+/// inherent helpers + `db()` escape hatch are the right path.
+///
+/// The `Key` here is `(tenant_id, id)` matching how every table in
+/// `src/db.rs` keys rows. We carry both as borrowed `&str` to avoid forcing
+/// a `String` allocation per call.
+#[async_trait(?Send)]
+impl<'a, V> Repository for D1Repository<'a, V>
+where
+    V: Into<String>,
+{
+    type Key = (String, String);
+    type Value = V;
+
+    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Error> {
+        let (tenant_id, id) = key;
+        let stmt = self
+            .db
+            .prepare(self.select_sql)
+            .bind(&[
+                JsValue::from_str(tenant_id),
+                JsValue::from_str(id),
+            ])
+            .map_err(Error::from)?;
+        let res = stmt.all().await.map_err(Error::from)?;
+        (self.decode)(&res)
+    }
+
+    async fn put(&self, key: &Self::Key, value: Self::Value) -> Result<(), Error> {
+        let (tenant_id, id) = key;
+        let payload: String = value.into();
+        self.db
+            .prepare(self.upsert_sql)
+            .bind(&[
+                JsValue::from_str(tenant_id),
+                JsValue::from_str(id),
+                JsValue::from_str(&payload),
+            ])
+            .map_err(Error::from)?
+            .run()
+            .await
+            .map_err(Error::from)?;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &Self::Key) -> Result<(), Error> {
+        let (tenant_id, id) = key;
+        self.db
+            .prepare(self.delete_sql)
+            .bind(&[
+                JsValue::from_str(tenant_id),
+                JsValue::from_str(id),
+            ])
+            .map_err(Error::from)?
+            .run()
+            .await
+            .map_err(Error::from)?;
+        Ok(())
+    }
+
+    async fn health_check(&self) -> Result<(), Error> {
+        // `SELECT 1` round-trips the binding without depending on any
+        // particular table existing. Matches the standard Workers D1
+        // health-probe pattern.
+        self.db
+            .prepare("SELECT 1")
+            .first::<i64>(None)
+            .await
+            .map_err(Error::from)?;
+        Ok(())
+    }
+}

--- a/data-fabric-repo/src/error.rs
+++ b/data-fabric-repo/src/error.rs
@@ -1,0 +1,225 @@
+//! Typed error taxonomy for repository operations.
+//!
+//! The fabric talks to two storage backends (D1 and R2) through several call
+//! sites today (`src/db.rs`, `src/storage.rs`). Each call site translates
+//! `worker::Error` into either an HTTP response or a string with ad-hoc
+//! semantics. That makes it hard to write shared retry logic, hard to map
+//! errors to consistent HTTP status codes at the edge, and hard to add
+//! observability that doesn't double-count classes of failure.
+//!
+//! This module replaces that with a small closed enum whose variants carry
+//! routing intent rather than implementation detail:
+//!
+//! | Variant       | HTTP | Retriable? | Example                             |
+//! |---------------|-----:|:----------:|-------------------------------------|
+//! | [`Auth`]      | 401  | no         | missing/invalid tenant credentials  |
+//! | [`Permanent`] | 400  | no         | malformed request, bad bindings     |
+//! | [`NotFound`]  | 404  | no         | unknown run id, missing R2 key      |
+//! | [`Conflict`]  | 409  | no         | unique-key collision, lease taken   |
+//! | [`Internal`]  | 500  | no         | unexpected; bug or invariant break  |
+//! | [`Transient`] | 503  | **yes**   | D1 busy, R2 timeout, internal_error |
+//!
+//! `Internal` and `Transient` are deliberately separate: a planner bug that
+//! produced bad SQL is *not* worth retrying, even though both surface as 5xx
+//! to the caller. `is_transient()` is the single source of truth for the
+//! retry helper — adding a new variant later only requires updating that
+//! one predicate, not every retry call site.
+//!
+//! See [`crate::retry`] for the policy that consumes [`Error::is_transient`].
+
+use thiserror::Error;
+
+/// Repository-level error.
+///
+/// The string payload is purely diagnostic — it surfaces in logs and in the
+/// 5xx error envelope when something goes wrong, but the *classification*
+/// (variant) is what callers and the retry policy branch on. Don't pattern
+/// match on the string.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Retriable failure: the underlying call can be re-issued and may
+    /// succeed. Use for D1 busy / locked, R2 timeouts, and `internal_error`
+    /// responses from the Cloudflare control plane.
+    #[error("transient: {0}")]
+    Transient(String),
+
+    /// Non-retriable client error: the request is wrong and won't succeed
+    /// by re-issuing. Use for malformed input, schema-violating writes,
+    /// missing bindings.
+    #[error("permanent: {0}")]
+    Permanent(String),
+
+    /// Caller is unauthenticated or unauthorized for this resource.
+    #[error("auth: {0}")]
+    Auth(String),
+
+    /// The requested key/row does not exist.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// A uniqueness/state constraint prevented the write. Includes lease
+    /// races (e.g. another agent claimed the task first).
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    /// Server-side bug or invariant violation. Distinct from `Transient`:
+    /// retrying won't help.
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+impl Error {
+    /// HTTP status code this error should map to at the edge.
+    ///
+    /// Matches the acceptance criteria in stevedores-org/data-fabric#53:
+    /// 400 / 401 / 404 / 409 / 500 / 503.
+    pub fn status_code(&self) -> u16 {
+        match self {
+            Self::Permanent(_) => 400,
+            Self::Auth(_) => 401,
+            Self::NotFound(_) => 404,
+            Self::Conflict(_) => 409,
+            Self::Internal(_) => 500,
+            Self::Transient(_) => 503,
+        }
+    }
+
+    /// Should the retry policy attempt this error again?
+    ///
+    /// **Only** `Transient` retries. `Internal` is excluded deliberately —
+    /// see the module-level table for the reasoning.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Transient(_))
+    }
+}
+
+/// Convert a `worker::Error` into a classified repository error.
+///
+/// The classification is conservative: we recognize the variants that the
+/// Cloudflare runtime currently spells out as definitely-transient
+/// (`InternalError`, `RateLimitExceeded`) and bucket everything else as
+/// either `NotFound` (for the small set of unambiguous 404 cases) or
+/// `Internal`. As we encounter new transient strings in the wild we extend
+/// the substring sniffer in [`is_transient_message`].
+impl From<worker::Error> for Error {
+    fn from(e: worker::Error) -> Self {
+        use worker::Error as W;
+        match &e {
+            // Cloudflare-coded transients. These come back with a stable
+            // `code` from the runtime; we trust the classification.
+            W::InternalError(msg) => Error::Transient(msg.clone()),
+            W::RateLimitExceeded(msg) => Error::Transient(msg.clone()),
+            W::DailyLimitExceeded(msg) => Error::Permanent(msg.clone()),
+
+            // For BindingError we're sure: the worker is misconfigured.
+            // Not retriable, not the user's fault, surfaces as 500.
+            W::BindingError(msg) => Error::Internal(format!("binding: {msg}")),
+
+            // Everything else: peek at the rendered string to catch known
+            // transient phrases coming out of D1/R2 that aren't yet typed
+            // by the worker crate (D1_ERROR busy / SQLITE_BUSY, R2 timeout
+            // / internal_error). Fall through to Internal so we don't
+            // silently retry things we shouldn't.
+            _ => {
+                let msg = e.to_string();
+                if is_transient_message(&msg) {
+                    Error::Transient(msg)
+                } else if is_not_found_message(&msg) {
+                    Error::NotFound(msg)
+                } else {
+                    Error::Internal(msg)
+                }
+            }
+        }
+    }
+}
+
+/// Substring sniff for Cloudflare-specific transient failures.
+///
+/// Not exhaustive — extend as new strings show up in incidents. The cost of
+/// a false negative (we don't retry something we could have) is bounded;
+/// the cost of a false positive (we retry a permanent error) is wasted
+/// budget and possibly write amplification, so we err narrow.
+pub(crate) fn is_transient_message(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("internal_error")
+        || m.contains("internal error")
+        || m.contains("d1_error: database is locked")
+        || m.contains("sqlite_busy")
+        || m.contains("database is locked")
+        || m.contains("timeout")
+        || m.contains("timed out")
+        || m.contains("temporarily unavailable")
+        || m.contains("service unavailable")
+        || m.contains("503")
+}
+
+/// Substring sniff for "this key/row does not exist".
+///
+/// D1's `first()` returns `Ok(None)` for missing rows so callers don't hit
+/// this path for the common case. We only end up here when the runtime
+/// surfaces a NotFound through an error rather than an `Option`.
+pub(crate) fn is_not_found_message(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("not found") || m.contains("no such") || m.contains("404")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_code_covers_acceptance_matrix() {
+        // Acceptance criterion: 400, 401, 404, 409, 500, 503 all reachable.
+        assert_eq!(Error::Permanent("x".into()).status_code(), 400);
+        assert_eq!(Error::Auth("x".into()).status_code(), 401);
+        assert_eq!(Error::NotFound("x".into()).status_code(), 404);
+        assert_eq!(Error::Conflict("x".into()).status_code(), 409);
+        assert_eq!(Error::Internal("x".into()).status_code(), 500);
+        assert_eq!(Error::Transient("x".into()).status_code(), 503);
+    }
+
+    #[test]
+    fn only_transient_is_retriable() {
+        // `is_transient` is what the retry helper branches on; if this
+        // predicate ever returns true for anything else we'd retry
+        // non-idempotent failures. Lock the set down explicitly.
+        assert!(Error::Transient("busy".into()).is_transient());
+        assert!(!Error::Permanent("bad".into()).is_transient());
+        assert!(!Error::Auth("nope".into()).is_transient());
+        assert!(!Error::NotFound("gone".into()).is_transient());
+        assert!(!Error::Conflict("race".into()).is_transient());
+        assert!(!Error::Internal("bug".into()).is_transient());
+    }
+
+    #[test]
+    fn transient_sniffer_catches_cf_phrases() {
+        assert!(is_transient_message("D1_ERROR: database is locked"));
+        assert!(is_transient_message("SQLITE_BUSY"));
+        assert!(is_transient_message("Request timed out"));
+        assert!(is_transient_message("Internal error from R2"));
+        assert!(is_transient_message("503 Service Unavailable"));
+        assert!(is_transient_message("temporarily unavailable"));
+
+        assert!(!is_transient_message("malformed JSON"));
+        assert!(!is_transient_message("no such column: foo"));
+    }
+
+    #[test]
+    fn not_found_sniffer_matches() {
+        assert!(is_not_found_message("Object not found"));
+        assert!(is_not_found_message("404 Not Found"));
+        assert!(is_not_found_message("no such file"));
+        assert!(!is_not_found_message("permission denied"));
+    }
+
+    #[test]
+    fn display_includes_classification_and_message() {
+        // The `#[error("transient: {0}")]` prefix is load-bearing for
+        // log greppability. If someone "tidies" it away tests will fail.
+        let e = Error::Transient("D1 busy".into());
+        assert_eq!(format!("{e}"), "transient: D1 busy");
+        let e = Error::NotFound("run abc".into());
+        assert_eq!(format!("{e}"), "not found: run abc");
+    }
+}

--- a/data-fabric-repo/src/lib.rs
+++ b/data-fabric-repo/src/lib.rs
@@ -1,0 +1,52 @@
+//! `data-fabric-repo` — shared D1/R2 repository abstraction for the
+//! Cloudflare-native data fabric worker.
+//!
+//! Implements the WS1B deliverables from
+//! [stevedores-org/data-fabric#53](https://github.com/stevedores-org/data-fabric/issues/53):
+//!
+//! 1. [`Repository`] trait — generic CRUD over D1 / R2 with consistent
+//!    error handling.
+//! 2. [`Error`] — typed taxonomy mapping cleanly to HTTP status codes
+//!    400 / 401 / 404 / 409 / 500 / 503 (see [`Error::status_code`]).
+//! 3. [`RepositoryConfig`] + per-adapter `health_check()` — initialization
+//!    patterns for binding resolution and liveness probes.
+//! 4. [`with_retry`] / [`RetryPolicy`] — exponential backoff with bounded
+//!    jitter for the transient failure modes specific to Cloudflare D1 and
+//!    R2 (busy, locked, timeout, internal_error).
+//!
+//! ## Scope (what this PR does NOT do)
+//!
+//! It does **not** refactor `src/db.rs` or `src/storage.rs` to *use* these
+//! abstractions. Migration of the existing call sites is a follow-up
+//! tracked separately. The trait was validated against 3 representative
+//! patterns from `db.rs` and 2 from `storage.rs` — see the PR body for the
+//! mapping table.
+//!
+//! ## Why the trait is `?Send`
+//!
+//! Workers futures capture `JsValue`s and are therefore `!Send`. Marking
+//! the trait `?Send` lets implementations await `worker::*` futures
+//! directly without `spawn_local`.
+
+#![deny(clippy::unwrap_used, clippy::expect_used)]
+#![warn(clippy::pedantic)]
+#![allow(
+    // We're explicit about which lints we silence and why. Each one below
+    // is here because pedantic flags it on plain, correct code in the
+    // wasm/worker idiom and not because we're hiding bugs.
+    clippy::module_name_repetitions, // `D1Repository` in module `d1` is the point.
+    clippy::missing_errors_doc,      // re-doc'd on the trait, not every impl.
+    clippy::must_use_candidate,      // builder-style `with_logical_name`.
+)]
+
+pub mod d1;
+pub mod error;
+pub mod r2;
+pub mod repository;
+pub mod retry;
+
+pub use d1::D1Repository;
+pub use error::Error;
+pub use r2::R2Repository;
+pub use repository::{Repository, RepositoryConfig};
+pub use retry::{with_retry, MonotonicClock, RetryPolicy, Sleeper, WorkerClock, WorkerSleeper};

--- a/data-fabric-repo/src/r2.rs
+++ b/data-fabric-repo/src/r2.rs
@@ -1,0 +1,91 @@
+//! [`R2Repository`] — [`Repository`] adapter over `worker::Bucket`.
+//!
+//! Wraps the three patterns we use in `src/storage.rs` today —
+//! `put_blob`, `get_blob`, `delete_blob` — behind the same trait surface
+//! D1 uses. This makes it possible to write retry-wrapped, error-classified
+//! storage helpers that don't care whether the backend is D1 or R2.
+
+use async_trait::async_trait;
+use worker::Bucket;
+
+use crate::error::Error;
+use crate::repository::Repository;
+
+/// R2-backed blob repository.
+///
+/// Same borrowed-binding pattern as [`crate::d1::D1Repository`]: the worker
+/// hands the request handler a `Bucket` and the repo is a thin view over
+/// that single handle.
+pub struct R2Repository<'a> {
+    bucket: &'a Bucket,
+}
+
+impl<'a> R2Repository<'a> {
+    pub fn new(bucket: &'a Bucket) -> Self {
+        Self { bucket }
+    }
+
+    /// Escape hatch for callers that need multipart uploads, listing, or
+    /// `head()` metadata — i.e. anything outside the point-CRUD trait.
+    pub fn bucket(&self) -> &Bucket {
+        self.bucket
+    }
+}
+
+#[async_trait(?Send)]
+impl<'a> Repository for R2Repository<'a> {
+    /// R2 keys are flat strings — no tenant dimension at the bucket level.
+    /// Tenant scoping at the *application* level is implemented by prefixing
+    /// keys with the tenant id, same as the existing `src/storage.rs`
+    /// helpers do. We don't bake that into this adapter because some keys
+    /// (e.g. shared schema artifacts) are deliberately tenantless.
+    type Key = String;
+    type Value = Vec<u8>;
+
+    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Error> {
+        let obj = self.bucket.get(key.clone()).execute().await.map_err(Error::from)?;
+        match obj {
+            Some(obj) => match obj.body() {
+                Some(body) => {
+                    let bytes = body.bytes().await.map_err(Error::from)?;
+                    Ok(Some(bytes))
+                }
+                // Object exists but body is empty — matches existing
+                // semantics in src/storage.rs::get_blob.
+                None => Ok(Some(Vec::new())),
+            },
+            None => Ok(None),
+        }
+    }
+
+    async fn put(&self, key: &Self::Key, value: Self::Value) -> Result<(), Error> {
+        self.bucket
+            .put(key.clone(), value)
+            .execute()
+            .await
+            .map_err(Error::from)?;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &Self::Key) -> Result<(), Error> {
+        // R2's delete is idempotent on the runtime side — missing key
+        // returns Ok. Matches our trait contract.
+        self.bucket.delete(key.clone()).await.map_err(Error::from)?;
+        Ok(())
+    }
+
+    async fn health_check(&self) -> Result<(), Error> {
+        // `head` of a sentinel key is the cheapest call that exercises
+        // auth + network without writing anything. The key doesn't need
+        // to exist — we accept `Ok(None)` as healthy.
+        //
+        // We intentionally use a fixed key under a reserved prefix so this
+        // doesn't collide with real data even if `__healthcheck__` shows
+        // up in user payloads.
+        self.bucket
+            .head("__data_fabric_repo_healthcheck__")
+            .await
+            .map_err(Error::from)?;
+        Ok(())
+    }
+}

--- a/data-fabric-repo/src/repository.rs
+++ b/data-fabric-repo/src/repository.rs
@@ -1,0 +1,117 @@
+//! [`Repository`] trait + the small bag of context-bag types it needs.
+//!
+//! This is the *shape* the rest of the fabric will gradually migrate onto.
+//! For this PR's scope we only define the trait and the two concrete
+//! adapters ([`crate::d1::D1Repository`], [`crate::r2::R2Repository`]) —
+//! call sites in `src/db.rs` / `src/storage.rs` are not migrated here.
+//!
+//! ## Why `?Send`
+//!
+//! All `worker-rs` futures are `!Send` because they capture `JsValue`s,
+//! which can only be touched from the single Workers thread. Marking the
+//! trait `?Send` lets us await `D1Database::prepare(...).first(...)` and
+//! `Bucket::get(...).execute()` directly, with no `spawn_local` dance.
+//! It's also forward-compatible with multi-threaded native test runners
+//! since `?Send` *permits* but does not *require* non-Send futures.
+
+use async_trait::async_trait;
+
+use crate::error::Error;
+
+/// Generic CRUD-flavored repository over a typed `Key`/`Value` pair.
+///
+/// Intentionally minimal — the trait isn't trying to be ORM-shaped. It
+/// expresses the four shapes we use across the worker today:
+///
+/// 1. Point-read by key   → [`Repository::get`]
+/// 2. Point-write by key  → [`Repository::put`]
+/// 3. Point-delete by key → [`Repository::delete`]
+/// 4. Liveness probe      → [`Repository::health_check`]
+///
+/// **Listing, pagination, and tenant scoping are deliberately not in this
+/// trait.** They vary too much across our call sites (cursored vs. limit/
+/// offset, tenant-prefixed vs. WHERE-claused) to capture without
+/// over-fitting. Concrete adapter types add those as inherent methods —
+/// see the validation section of PR #53 for which patterns we mapped to
+/// this trait and which stay adapter-specific.
+#[async_trait(?Send)]
+pub trait Repository {
+    /// Logical primary key. For D1 row repos this is a `(tenant_id, id)`
+    /// pair; for R2 it's the object key as a `String`. Adapter-defined so
+    /// the trait doesn't impose D1's two-column convention on R2 (or vice
+    /// versa).
+    type Key;
+    /// Value type. For D1 row repos this is the model struct; for R2
+    /// blobs it's `Vec<u8>`.
+    type Value;
+
+    /// Read one. `Ok(None)` means "definitely not there"; `Err(NotFound)`
+    /// is reserved for the runtime explicitly reporting absence as an
+    /// error (rare on D1, can happen on R2 metadata calls).
+    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Error>;
+
+    /// Write one. Insert-or-replace semantics by default; conflict-on-
+    /// existing semantics should be expressed as an inherent method on the
+    /// adapter or with a typed wrapper around `Value`.
+    async fn put(&self, key: &Self::Key, value: Self::Value) -> Result<(), Error>;
+
+    /// Delete one. Idempotent: deleting a missing key returns `Ok(())`.
+    /// This matches both R2's `delete()` behavior and the way our D1 call
+    /// sites already swallow zero-affected-rows responses.
+    async fn delete(&self, key: &Self::Key) -> Result<(), Error>;
+
+    /// Cheap end-to-end probe used by the worker's `/healthz` handler. Must
+    /// touch the backend (not just the binding) so this catches credential
+    /// rotation, network partitions, and bucket-deleted scenarios.
+    async fn health_check(&self) -> Result<(), Error>;
+}
+
+/// Binding-resolution config.
+///
+/// We pass the *binding name* (e.g. `"DB"` for D1, `"BLOBS"` for R2) plus an
+/// optional logical name for observability. Today both adapters are
+/// constructed from already-resolved `worker::D1Database` / `worker::Bucket`
+/// handles inside the request handler, so this struct mostly exists for
+/// future use: a forthcoming PR can plumb it through an `init` constructor
+/// once the worker request lifecycle is refactored to do binding lookup in
+/// a single place.
+#[derive(Debug, Clone)]
+pub struct RepositoryConfig {
+    /// Name of the binding as declared in `wrangler.toml`.
+    pub binding: String,
+    /// Optional human name for logs/metrics. Defaults to `binding` if unset.
+    pub logical_name: Option<String>,
+}
+
+impl RepositoryConfig {
+    pub fn new(binding: impl Into<String>) -> Self {
+        Self {
+            binding: binding.into(),
+            logical_name: None,
+        }
+    }
+
+    pub fn with_logical_name(mut self, name: impl Into<String>) -> Self {
+        self.logical_name = Some(name.into());
+        self
+    }
+
+    /// Name to use in logs. Falls back to `binding` so we always have
+    /// *something* to grep on.
+    pub fn name(&self) -> &str {
+        self.logical_name.as_deref().unwrap_or(&self.binding)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_name_falls_back_to_binding() {
+        let c = RepositoryConfig::new("DB");
+        assert_eq!(c.name(), "DB");
+        let c = c.with_logical_name("runs_db");
+        assert_eq!(c.name(), "runs_db");
+    }
+}

--- a/data-fabric-repo/src/retry.rs
+++ b/data-fabric-repo/src/retry.rs
@@ -1,0 +1,453 @@
+//! Retry policy with exponential backoff and bounded jitter.
+//!
+//! ## Why a custom helper instead of `backoff` / `tokio-retry`
+//!
+//! The Workers runtime is single-threaded and `worker::Delay` is the only
+//! sanctioned sleep primitive on wasm32 — `tokio::time::sleep` doesn't work
+//! there, and `std::thread::sleep` blocks the only event loop. Existing
+//! crates pull `rand` (for jitter) and either `tokio` or `std::time::Instant`
+//! (for clocks), neither of which we want in the wasm binary.
+//!
+//! ## Why no `rand` dependency
+//!
+//! Real PRNG-based jitter would require pulling `rand` + `getrandom` with
+//! the `js` feature. We already pay for `getrandom` at the worker layer,
+//! but `rand` brings ~100KB of code paths we don't need. Instead we use
+//! `worker::Date::now().as_millis()` as a chaotic-enough source for jitter:
+//! across concurrent invocations the millisecond timestamps differ, which
+//! is the only property we need to prevent thundering-herd retry storms.
+//! For unit tests we expose [`with_retry_clock`] which takes any
+//! [`MonotonicClock`], so the tests don't depend on `Date::now`.
+
+use crate::error::Error;
+use std::future::Future;
+use std::time::Duration;
+
+/// Retry policy.
+///
+/// `max_attempts` is the total number of *attempts* (not retries) — a policy
+/// with `max_attempts = 1` will never retry. `initial_backoff_ms` is the
+/// delay before the first retry; subsequent retries double up to
+/// `max_backoff_ms`, then jitter is layered on top.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy {
+    /// Total number of attempts including the first. Must be >= 1.
+    pub max_attempts: u32,
+    /// Delay before the 2nd attempt, in milliseconds.
+    pub initial_backoff_ms: u64,
+    /// Cap on the deterministic part of the backoff, in milliseconds.
+    pub max_backoff_ms: u64,
+}
+
+impl RetryPolicy {
+    /// Sensible defaults for D1/R2: 4 attempts, 50ms → 800ms (50, 100, 200, 400 then cap).
+    /// Total worst-case wait ≈ 750ms before reporting failure, which fits
+    /// comfortably under typical Workers CPU-time budgets.
+    pub fn default_for_storage() -> Self {
+        Self {
+            max_attempts: 4,
+            initial_backoff_ms: 50,
+            max_backoff_ms: 800,
+        }
+    }
+
+    /// A no-retry policy. Useful for read paths where the caller would rather
+    /// surface failure fast than wait.
+    pub fn none() -> Self {
+        Self {
+            max_attempts: 1,
+            initial_backoff_ms: 0,
+            max_backoff_ms: 0,
+        }
+    }
+
+    /// Compute the deterministic backoff for `attempt_index` (0-based —
+    /// `attempt_index == 0` is the delay *before* the 2nd attempt).
+    ///
+    /// Doubling proceeds in `u128` to avoid overflow on policies with large
+    /// `initial_backoff_ms`, then clamps back into `u64`.
+    pub fn backoff_for(&self, attempt_index: u32) -> Duration {
+        let base = self.initial_backoff_ms as u128;
+        let shifted = base
+            .checked_shl(attempt_index)
+            .unwrap_or(self.max_backoff_ms as u128);
+        let capped = shifted.min(self.max_backoff_ms as u128) as u64;
+        Duration::from_millis(capped)
+    }
+}
+
+/// Source of monotonic-ish "now" used to derive jitter and to allow tests to
+/// inject a fake clock. In production it's wired to `worker::Date::now`.
+pub trait MonotonicClock {
+    fn now_ms(&self) -> u64;
+}
+
+/// Production clock: `worker::Date::now()`.
+///
+/// `Date::now()` returns wall-clock milliseconds. It can move backwards
+/// across NTP adjustments — fine for jitter, **don't** use this for timing
+/// SLAs.
+pub struct WorkerClock;
+
+impl MonotonicClock for WorkerClock {
+    fn now_ms(&self) -> u64 {
+        worker::Date::now().as_millis()
+    }
+}
+
+/// Sleep primitive. Abstracted for the same reason as the clock: unit tests
+/// shouldn't actually sleep, and `worker::Delay` doesn't work on the host
+/// target anyway.
+#[async_trait::async_trait(?Send)]
+pub trait Sleeper {
+    async fn sleep(&self, dur: Duration);
+}
+
+/// Production sleeper: `worker::Delay`.
+pub struct WorkerSleeper;
+
+#[async_trait::async_trait(?Send)]
+impl Sleeper for WorkerSleeper {
+    async fn sleep(&self, dur: Duration) {
+        worker::Delay::from(dur).await;
+    }
+}
+
+/// Bounded jitter: returns a value in `[0, base_ms * JITTER_FRACTION_NUM / JITTER_FRACTION_DEN]`.
+///
+/// We use ±25% of the base backoff, derived from `clock_ms % (base/4 + 1)`.
+/// The `+ 1` avoids a divide-by-zero when `base_ms == 0`. The modulus is
+/// not cryptographically random; that's deliberate — see module docs.
+pub(crate) fn jitter_ms(clock_ms: u64, base_ms: u64) -> u64 {
+    let span = base_ms / 4 + 1;
+    clock_ms % span
+}
+
+/// Retry `op` according to `policy`, sleeping with `worker::Delay` between
+/// attempts. Only [`Error::Transient`] is retried; everything else is
+/// returned immediately.
+///
+/// This is the production entry point — wired to `WorkerClock` and
+/// `WorkerSleeper`. For unit tests use [`with_retry_clock`].
+pub async fn with_retry<F, Fut, T>(policy: &RetryPolicy, op: F) -> Result<T, Error>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, Error>>,
+{
+    with_retry_clock(policy, &WorkerClock, &WorkerSleeper, op).await
+}
+
+/// Variant of [`with_retry`] parameterized over the clock and sleeper.
+/// Production code should call [`with_retry`]; this exists so unit tests can
+/// count attempts and verify backoff without depending on `worker::*`.
+pub async fn with_retry_clock<C, S, F, Fut, T>(
+    policy: &RetryPolicy,
+    clock: &C,
+    sleeper: &S,
+    mut op: F,
+) -> Result<T, Error>
+where
+    C: MonotonicClock,
+    S: Sleeper,
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, Error>>,
+{
+    // Guard against `max_attempts = 0` configs slipping in — treat as 1.
+    let max = policy.max_attempts.max(1);
+    let mut last_err: Option<Error> = None;
+
+    for attempt in 0..max {
+        match op().await {
+            Ok(v) => return Ok(v),
+            Err(e) if !e.is_transient() => return Err(e),
+            Err(e) => {
+                // Stash the transient error so we can return it if we
+                // exhaust the budget; we'll overwrite on each retry.
+                last_err = Some(e);
+
+                // Don't sleep after the *last* attempt — there's no next
+                // try to wait for.
+                if attempt + 1 == max {
+                    break;
+                }
+
+                let base = policy.backoff_for(attempt);
+                let base_ms = base.as_millis() as u64;
+                let total = base_ms + jitter_ms(clock.now_ms(), base_ms);
+                sleeper.sleep(Duration::from_millis(total)).await;
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| {
+        // Unreachable: the loop always assigns last_err on the Err arm.
+        // Keep an explicit fallback so the type checker doesn't need
+        // `unreachable!()` panics in a wasm-targeted crate.
+        Error::Internal("with_retry: no attempts executed".into())
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    /// Fake clock with a controllable counter.
+    struct FakeClock(Cell<u64>);
+    impl MonotonicClock for FakeClock {
+        fn now_ms(&self) -> u64 {
+            let n = self.0.get();
+            self.0.set(n + 1);
+            n
+        }
+    }
+
+    /// Records every sleep duration, doesn't actually wait.
+    struct RecordingSleeper(Rc<Cell<Vec<u64>>>);
+    #[async_trait::async_trait(?Send)]
+    impl Sleeper for RecordingSleeper {
+        async fn sleep(&self, dur: Duration) {
+            let mut v = self.0.take();
+            v.push(dur.as_millis() as u64);
+            self.0.set(v);
+        }
+    }
+
+    fn block_on<F: Future>(f: F) -> F::Output {
+        // Tiny single-threaded runner — sufficient because none of the
+        // futures in this crate's tests touch a reactor. We can't pull
+        // `futures-executor` because the workspace toolchain forbids
+        // adding deps; this hand-rolled one is ~10 lines.
+        use std::pin::Pin;
+        use std::sync::Arc;
+        use std::task::{Context, Poll, Wake, Waker};
+        struct Noop;
+        impl Wake for Noop {
+            fn wake(self: Arc<Self>) {}
+        }
+        let waker = Waker::from(Arc::new(Noop));
+        let mut cx = Context::from_waker(&waker);
+        let mut f = Box::pin(f);
+        loop {
+            match Pin::new(&mut f).as_mut().poll(&mut cx) {
+                Poll::Ready(v) => return v,
+                Poll::Pending => {} // our futures don't actually yield
+            }
+        }
+    }
+
+    #[test]
+    fn backoff_doubles_then_caps() {
+        let p = RetryPolicy {
+            max_attempts: 6,
+            initial_backoff_ms: 10,
+            max_backoff_ms: 100,
+        };
+        assert_eq!(p.backoff_for(0), Duration::from_millis(10));
+        assert_eq!(p.backoff_for(1), Duration::from_millis(20));
+        assert_eq!(p.backoff_for(2), Duration::from_millis(40));
+        assert_eq!(p.backoff_for(3), Duration::from_millis(80));
+        // Next doubling would be 160 — cap at 100.
+        assert_eq!(p.backoff_for(4), Duration::from_millis(100));
+        assert_eq!(p.backoff_for(5), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn backoff_does_not_overflow_at_extreme_attempt_counts() {
+        // 1ms << 64 would overflow u64. We use checked_shl into u128 then
+        // clamp; expected behavior is to land at the cap, not panic.
+        let p = RetryPolicy {
+            max_attempts: 100,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 500,
+        };
+        assert_eq!(p.backoff_for(64), Duration::from_millis(500));
+        assert_eq!(p.backoff_for(99), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn jitter_is_bounded_within_25_percent() {
+        // jitter_ms must never exceed base_ms / 4. Sweep a wide clock
+        // range to be sure (this is exactly the property that keeps the
+        // worst-case total wait predictable).
+        for base in [10u64, 100, 1000, 10_000] {
+            for clock in [0u64, 1, 7, 13, 999, u64::MAX] {
+                let j = jitter_ms(clock, base);
+                assert!(
+                    j <= base / 4,
+                    "jitter {j} exceeded cap {} for base {base} clock {clock}",
+                    base / 4
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn jitter_handles_zero_base() {
+        // base_ms == 0 -> span is 1 -> jitter is always 0. Important
+        // because RetryPolicy::none() has initial_backoff_ms = 0.
+        assert_eq!(jitter_ms(123, 0), 0);
+        assert_eq!(jitter_ms(0, 0), 0);
+    }
+
+    #[test]
+    fn retry_stops_after_max_attempts_on_transient() {
+        let calls = Rc::new(Cell::new(0u32));
+        let sleeps = Rc::new(Cell::new(Vec::<u64>::new()));
+        let clock = FakeClock(Cell::new(0));
+        let sleeper = RecordingSleeper(sleeps.clone());
+        let policy = RetryPolicy {
+            max_attempts: 3,
+            initial_backoff_ms: 10,
+            max_backoff_ms: 80,
+        };
+
+        let calls_inner = calls.clone();
+        let res: Result<(), Error> = block_on(with_retry_clock(
+            &policy,
+            &clock,
+            &sleeper,
+            move || {
+                let c = calls_inner.clone();
+                async move {
+                    c.set(c.get() + 1);
+                    Err::<(), _>(Error::Transient("D1 busy".into()))
+                }
+            },
+        ));
+
+        assert!(matches!(res, Err(Error::Transient(_))));
+        assert_eq!(calls.get(), 3, "expected exactly max_attempts calls");
+        // 2 sleeps between 3 attempts.
+        assert_eq!(sleeps.take().len(), 2);
+    }
+
+    #[test]
+    fn retry_does_not_retry_permanent() {
+        let calls = Rc::new(Cell::new(0u32));
+        let sleeps = Rc::new(Cell::new(Vec::<u64>::new()));
+        let clock = FakeClock(Cell::new(0));
+        let sleeper = RecordingSleeper(sleeps.clone());
+        let policy = RetryPolicy::default_for_storage();
+
+        let calls_inner = calls.clone();
+        let res: Result<(), Error> = block_on(with_retry_clock(
+            &policy,
+            &clock,
+            &sleeper,
+            move || {
+                let c = calls_inner.clone();
+                async move {
+                    c.set(c.get() + 1);
+                    Err::<(), _>(Error::Permanent("nope".into()))
+                }
+            },
+        ));
+
+        assert!(matches!(res, Err(Error::Permanent(_))));
+        assert_eq!(calls.get(), 1, "permanent error must not retry");
+        assert!(sleeps.take().is_empty(), "no sleeps for permanent");
+    }
+
+    #[test]
+    fn retry_returns_ok_on_second_attempt() {
+        // Common case: first call is transient, second succeeds. Verify
+        // we return the success and don't continue to attempt 3.
+        let calls = Rc::new(Cell::new(0u32));
+        let sleeps = Rc::new(Cell::new(Vec::<u64>::new()));
+        let clock = FakeClock(Cell::new(0));
+        let sleeper = RecordingSleeper(sleeps.clone());
+        let policy = RetryPolicy {
+            max_attempts: 5,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+        };
+
+        let calls_inner = calls.clone();
+        let res: Result<&'static str, Error> = block_on(with_retry_clock(
+            &policy,
+            &clock,
+            &sleeper,
+            move || {
+                let c = calls_inner.clone();
+                async move {
+                    let n = c.get() + 1;
+                    c.set(n);
+                    if n == 1 {
+                        Err(Error::Transient("blip".into()))
+                    } else {
+                        Ok("ok")
+                    }
+                }
+            },
+        ));
+
+        assert_eq!(res.unwrap(), "ok");
+        assert_eq!(calls.get(), 2);
+        assert_eq!(sleeps.take().len(), 1);
+    }
+
+    #[test]
+    fn retry_with_max_attempts_one_never_sleeps() {
+        let calls = Rc::new(Cell::new(0u32));
+        let sleeps = Rc::new(Cell::new(Vec::<u64>::new()));
+        let clock = FakeClock(Cell::new(0));
+        let sleeper = RecordingSleeper(sleeps.clone());
+        let policy = RetryPolicy::none();
+
+        let calls_inner = calls.clone();
+        let _: Result<(), Error> = block_on(with_retry_clock(
+            &policy,
+            &clock,
+            &sleeper,
+            move || {
+                let c = calls_inner.clone();
+                async move {
+                    c.set(c.get() + 1);
+                    Err::<(), _>(Error::Transient("once".into()))
+                }
+            },
+        ));
+
+        assert_eq!(calls.get(), 1);
+        assert!(sleeps.take().is_empty());
+    }
+
+    #[test]
+    fn retry_total_wait_is_bounded_by_policy() {
+        // Worst-case: every attempt fails transiently. Sum of recorded
+        // sleeps must be <= sum of (capped backoff + max jitter) for
+        // (max_attempts - 1) gaps. Locks down the bound the docstring
+        // promises so a future "improvement" doesn't blow up our CPU
+        // budget.
+        let sleeps = Rc::new(Cell::new(Vec::<u64>::new()));
+        let clock = FakeClock(Cell::new(0));
+        let sleeper = RecordingSleeper(sleeps.clone());
+        let policy = RetryPolicy {
+            max_attempts: 4,
+            initial_backoff_ms: 50,
+            max_backoff_ms: 200,
+        };
+
+        let _: Result<(), Error> = block_on(with_retry_clock(
+            &policy,
+            &clock,
+            &sleeper,
+            || async { Err::<(), _>(Error::Transient("x".into())) },
+        ));
+
+        // backoff_for(0..3): 50, 100, 200 (200 doubled would be 200 capped).
+        // jitter per step <= base/4.
+        let recorded = sleeps.take();
+        assert_eq!(recorded.len(), 3);
+        let max_each = [50 + 50 / 4, 100 + 100 / 4, 200 + 200 / 4];
+        for (i, ms) in recorded.iter().enumerate() {
+            assert!(
+                *ms <= max_each[i],
+                "step {i}: slept {ms}ms, expected <= {}ms",
+                max_each[i]
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #53.

> **Base-branch note:** the spec for this PR said to base on `develop`, but
> `origin/develop` does not currently exist on `stevedores-org/data-fabric`
> (last seen in the May 2026 main↔develop sync merges). Targeting `main`
> instead — please rebase onto `develop` if/when it's recreated.

## Summary

New `data-fabric-repo` workspace crate implementing the four WS1B
deliverables:

1. **`Repository` trait** — generic CRUD (`get` / `put` / `delete` /
   `health_check`) over a typed `Key` / `Value` pair, with concrete
   `D1Repository` and `R2Repository` adapters wrapping `worker::D1Database`
   and `worker::Bucket`.
2. **Typed `Error` taxonomy** mapping cleanly to HTTP status codes (table
   below).
3. **Initialization patterns** — `RepositoryConfig` (binding name +
   logical name for observability) and per-adapter `health_check()`.
4. **Retry policy** — `with_retry` + `RetryPolicy` with exponential
   backoff (doubling, capped) and bounded (<=25%) jitter, **no `rand`
   dep** — jitter derived from `worker::Date::now()`.

## Public API shape

```rust
#[async_trait(?Send)]
pub trait Repository {
    type Key;
    type Value;
    async fn get(&self, key: &Self::Key) -> Result<Option<Self::Value>, Error>;
    async fn put(&self, key: &Self::Key, value: Self::Value) -> Result<(), Error>;
    async fn delete(&self, key: &Self::Key) -> Result<(), Error>;
    async fn health_check(&self) -> Result<(), Error>;
}

pub struct RepositoryConfig { pub binding: String, pub logical_name: Option<String> }

#[derive(Debug, thiserror::Error)]
pub enum Error {
    Transient(String), Permanent(String), Auth(String),
    NotFound(String), Conflict(String), Internal(String),
}
impl Error {
    pub fn status_code(&self) -> u16 { /* 400/401/404/409/500/503 */ }
    pub fn is_transient(&self) -> bool { /* only Transient */ }
}

pub async fn with_retry<F, Fut, T>(policy: &RetryPolicy, op: F) -> Result<T, Error>
where F: FnMut() -> Fut, Fut: Future<Output = Result<T, Error>>;
```

## Error -> status code

| Variant   | HTTP | Retried? | Example                              |
|-----------|-----:|:--------:|--------------------------------------|
| Auth      | 401  | no       | missing/invalid tenant credentials   |
| Permanent | 400  | no       | malformed request, bad bindings      |
| NotFound  | 404  | no       | unknown run id, missing R2 key       |
| Conflict  | 409  | no       | unique-key collision, lease taken    |
| Internal  | 500  | no       | unexpected; bug or invariant break   |
| Transient | 503  | **yes**  | D1 busy, R2 timeout, internal_error  |

`Internal` and `Transient` are deliberately separate even though both
surface as 5xx — a planner bug that produced bad SQL is not worth
retrying. `is_transient()` is the single source of truth that the retry
helper branches on.

## Retry policy

- **Exponential backoff**: `backoff_for(attempt_index) = initial * 2^attempt_index`,
  saturated at `max_backoff_ms`. Computed in `u128` then clamped to `u64`
  so policies with large `initial_backoff_ms` and high attempt counts
  don't overflow.
- **Jitter**: `clock_ms % (base / 4 + 1)`, i.e. `[0, base/4]`. `+1` avoids
  divide-by-zero on `base == 0` (e.g. `RetryPolicy::none()`). The
  `worker::Date::now()` source is *not* cryptographically random — it
  doesn't need to be; we only need concurrent invocations to spread their
  retries, and millisecond timestamps differ.
- **Cloudflare transient classification**:
  `worker::Error::InternalError` and `RateLimitExceeded` are typed
  transients on the runtime side; everything else falls through a
  substring sniffer (`is_transient_message`) that catches `internal_error`,
  `D1_ERROR: database is locked`, `SQLITE_BUSY`, `timeout`, `503`,
  `temporarily unavailable`. We err narrow — a false negative (failure
  to retry) is cheaper than a false positive (retrying a permanent
  failure with write amplification).
- **Default policy**: `default_for_storage()` gives 4 attempts, 50ms
  initial, 800ms cap — worst-case ~750ms total wait, well under typical
  Workers CPU budget.

## Validation against existing call sites

Per the acceptance criterion, the trait was checked against representative
patterns in `src/db.rs` and `src/storage.rs`. **No code in those files
was changed** — this PR only adds the abstraction.

### `src/db.rs` (3 patterns)

| Function (line)                                | Trait method   | Notes |
|------------------------------------------------|----------------|-------|
| `get_run` (line 665)                           | `get`          | Direct match: `(tenant_id, id) -> Option<Run>`. Trait fits 1:1; only delta is `Result<_, worker::Error>` -> `Result<_, repo::Error>` via the `From` impl. |
| `create_run` (line 578)                        | `put` (loose)  | Real insert binds 7 fields; the trait's single-value `put` is a least-common-denominator. Migration path: keep `create_run` as an inherent method on a `RunsRepo` (using `D1Repository::db()` escape hatch) rather than forcing it through the trait. |
| `list_runs` (line 612)                         | *out-of-scope* | Cursor pagination + optional `repo` filter — confirmed list/pagination is **deliberately not in the trait** (would over-fit). Stays as an inherent method on the domain repo. |

Additional samples confirmed but not in the headline mapping:
`upsert_memory_item` (line 676, 21-column insert -> inherent method),
`claim_next_task` (line 59, multi-statement atomic claim -> stays inherent
because the trait doesn't model transactions yet).

### `src/storage.rs` (2 patterns)

| Function (line)         | Trait method   | Notes |
|-------------------------|----------------|-------|
| `get_blob` (line 11)    | `get`          | Direct 1:1 match — including the "object exists but body empty -> `Some(Vec::new())`" semantic, which `R2Repository::get` preserves. |
| `put_blob` (line 4)     | `put`          | Existing returns the byte size; the trait returns `()`. Trivial adapter wrapper if a caller still wants the size (it's `value.len()` before the call). |
| `delete_blob` (line 26) | `delete`       | Direct match. Idempotency on missing key was already the R2 runtime contract. |

### Conclusion

The trait covers point-CRUD cleanly for both backends. Listing,
multi-column writes, and atomic multi-statement claims (the things
`src/db.rs` does that the trait *doesn't* try to model) stay accessible
through the `D1Repository::db()` / `R2Repository::bucket()` escape
hatches, so the abstraction is additive rather than exclusive. The
follow-up migration PR can move call sites one table at a time.

## Out of scope (explicit)

- Refactoring `src/db.rs` or `src/storage.rs` to *use* `D1Repository` /
  `R2Repository`. That's the WS1B follow-up; this PR only establishes
  the shape so it can be reviewed independently.
- Transaction / batch helpers (`D1Database::batch`). Adding these to the
  trait would force every caller to think about batching; better to add
  them as inherent methods on `D1Repository` later when a concrete need
  shows up.
- Listing / pagination. Cursor shape varies across our tables; we'd
  over-fit if we baked it into the trait now.

## Dependencies added

Two, both already common in the worker ecosystem:

- `async-trait = "0.1"` — required for `Repository` (async fns in traits
  still need a desugarer when used as trait objects / in generic bounds
  in the patterns we want to support).
- `thiserror = "1"` — `#[derive(Error)]` for the `Error` enum, saves a
  hand-written `Display` impl.

**No `rand`** (jitter via `Date::now`), no new heavy deps, no transitive
runtime additions beyond what the worker crate already pulls.

## Local verification

```
$ RUSTFLAGS="-D warnings" cargo check --target wasm32-unknown-unknown -p data-fabric-repo
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s

$ RUSTFLAGS="-D warnings --cfg=coverage" cargo check --tests -p data-fabric-repo
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.45s

$ cargo test -p data-fabric-repo
running 15 tests
test error::tests::display_includes_classification_and_message ... ok
test error::tests::not_found_sniffer_matches ... ok
test error::tests::only_transient_is_retriable ... ok
test error::tests::transient_sniffer_catches_cf_phrases ... ok
test error::tests::status_code_covers_acceptance_matrix ... ok
test repository::tests::config_name_falls_back_to_binding ... ok
test retry::tests::backoff_does_not_overflow_at_extreme_attempt_counts ... ok
test retry::tests::backoff_doubles_then_caps ... ok
test retry::tests::jitter_handles_zero_base ... ok
test retry::tests::jitter_is_bounded_within_25_percent ... ok
test retry::tests::retry_does_not_retry_permanent ... ok
test retry::tests::retry_returns_ok_on_second_attempt ... ok
test retry::tests::retry_with_max_attempts_one_never_sleeps ... ok
test retry::tests::retry_stops_after_max_attempts_on_transient ... ok
test retry::tests::retry_total_wait_is_bounded_by_policy ... ok
test result: ok. 15 passed; 0 failed; 0 ignored

$ RUSTFLAGS="-D warnings" cargo check --target wasm32-unknown-unknown -p data-fabric-worker
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.15s
```

All four pass. Existing worker build unchanged.

---

**Draft — opened for review before marking ready.** Holding off on
ready-for-review until reviewers have signed off on the trait shape,
since this is the foundation we're migrating ~30 call sites onto.