### PR TITLE
fix(api): reconcile OpenAPI with handlers; POST /mcp/task/next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "data-fabric-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "reqwest",
  "serde",

--- a/data-fabric-client/Cargo.toml
+++ b/data-fabric-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-fabric-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Stevedores Org"]
 license = "Apache-2.0"

--- a/data-fabric-client/src/lib.rs
+++ b/data-fabric-client/src/lib.rs
@@ -201,10 +201,33 @@ impl Client {
         self.send_request(Method::POST, "/v1/tasks", Some(task)).await
     }
 
+    /// Build the HTTP request used by [`Client::claim_next_task`].
+    ///
+    /// Extracted so the method/URL/query-param shape can be unit-tested without
+    /// spinning up a mock server. The new contract (see PR #140) is:
+    ///
+    /// * `POST /mcp/task/next` — the operation is state-mutating (transfers
+    ///   ownership of a task), so it must use POST. GET now returns 405.
+    /// * `agent_id` is a required query parameter.
+    /// * `cap` is an optional comma-separated query parameter.
+    /// * No request body — inputs come exclusively from the query string.
+    pub fn build_claim_next_task_request(
+        &self,
+        agent_id: &str,
+        capabilities: &[String],
+    ) -> Result<reqwest::Request> {
+        let path = if capabilities.is_empty() {
+            format!("/mcp/task/next?agent_id={}", agent_id)
+        } else {
+            let caps = capabilities.join(",");
+            format!("/mcp/task/next?agent_id={}&cap={}", agent_id, caps)
+        };
+        self.prepare_request(Method::POST, &path).build().map_err(Error::from)
+    }
+
     pub async fn claim_next_task(&self, agent_id: &str, capabilities: &[String]) -> Result<Option<AgentTask>> {
-        let caps = capabilities.join(",");
-        let path = format!("/mcp/task/next?agent_id={}&cap={}", agent_id, caps);
-        let resp = self.prepare_request(Method::GET, &path).send().await?;
+        let req = self.build_claim_next_task_request(agent_id, capabilities)?;
+        let resp = self.http.execute(req).await?;
         if resp.status() == StatusCode::NO_CONTENT {
             return Ok(None);
         }
@@ -327,5 +350,63 @@ impl Client {
 
     pub async fn get_llama_context(&self, req: &ContextRequest) -> Result<ContextPackResponse> {
         self.send_request(Method::POST, "/v1/integrations/llama-rs/context", Some(req)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_client() -> Client {
+        Client::new(ClientConfig {
+            base_url: "https://df.example".to_string(),
+            tenant_id: "t-1".to_string(),
+            tenant_role: "builder".to_string(),
+            cf_client_id: None,
+            cf_client_secret: None,
+        })
+    }
+
+    /// Regression test for PR #140: `/mcp/task/next` flipped from GET to POST
+    /// in the worker, and the GET shim now returns 405. Every call from this
+    /// client must use POST or it will fail at runtime.
+    #[test]
+    fn claim_next_task_uses_post() {
+        let client = test_client();
+        let req = client
+            .build_claim_next_task_request("agent-1", &["rust".to_string(), "wasm".to_string()])
+            .expect("request must build");
+        assert_eq!(req.method(), &Method::POST, "must use POST per PR #140 contract");
+    }
+
+    /// `agent_id` and `cap` belong on the query string (the new POST handler
+    /// reads them from `url.query_pairs()`), not in a JSON body.
+    #[test]
+    fn claim_next_task_puts_inputs_in_query_string_not_body() {
+        let client = test_client();
+        let req = client
+            .build_claim_next_task_request("agent-1", &["rust".to_string(), "wasm".to_string()])
+            .expect("request must build");
+        let url = req.url();
+        assert_eq!(url.path(), "/mcp/task/next");
+        let query = url.query().expect("query string must be present");
+        assert!(query.contains("agent_id=agent-1"), "agent_id must be a query param, got: {query}");
+        assert!(query.contains("cap=rust,wasm"), "cap must be a comma-separated query param, got: {query}");
+        assert!(req.body().is_none(), "POST body must be empty; the handler reads from query params");
+    }
+
+    /// `cap` is optional per the OpenAPI spec — omit it entirely when no
+    /// capabilities are supplied (rather than sending `cap=`), so the
+    /// server-side parser doesn't see an empty capability set as a single
+    /// empty-string capability.
+    #[test]
+    fn claim_next_task_omits_cap_when_no_capabilities() {
+        let client = test_client();
+        let req = client
+            .build_claim_next_task_request("agent-1", &[])
+            .expect("request must build");
+        let query = req.url().query().unwrap_or("");
+        assert!(query.contains("agent_id=agent-1"));
+        assert!(!query.contains("cap="), "cap must be omitted when no capabilities are supplied, got: {query}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -743,7 +743,11 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 status: "pending".into(),
             })
         })
-        .get_async("/mcp/task/next", |req, ctx| async move {
+        // POST /mcp/task/next — claims the next pending task for an agent.
+        // This is a state-mutating, non-idempotent operation, so POST is the correct
+        // HTTP method. Caching proxies must not cache a "claimed" state, and retry
+        // middleware that auto-retries idempotent verbs must not double-claim.
+        .post_async("/mcp/task/next", |req, ctx| async move {
             let tenant_ctx = tenant::tenant_from_request(&req)?;
             let url = req.url()?;
             let params: std::collections::HashMap<String, String> = url
@@ -759,7 +763,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
 
             let namespace = ctx.env.durable_object("TASK_LEASE_MANAGER")?;
             let stub = namespace.id_from_name(&tenant_ctx.tenant_id)?.get_stub()?;
-            
+
             let do_url = format!("https://do/claim?agent_id={}&caps={}", agent_id, caps);
             let do_req = Request::new(&do_url, Method::Post)?;
             let mut do_resp = stub.fetch_with_request(do_req).await?;
@@ -770,7 +774,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
 
 
             let mut task: models::AgentTask = do_resp.json().await?;
-            
+
             // Sync to D1 (best effort)
             let d1 = ctx.env.d1("DB")?;
             let _ = db::sync_task_status(&d1, &tenant_ctx.tenant_id, &task).await;
@@ -788,6 +792,37 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 task.memory_context = memory_context;
             }
             Response::from_json(&task)
+        })
+        // DEPRECATED: GET /mcp/task/next was the original (incorrect) shape of this
+        // endpoint. It is being kept for one release as a compatibility shim that
+        // returns 405 Method Not Allowed with `Allow: POST` and a `Deprecation`
+        // header so legacy clients get an immediate, actionable failure rather than
+        // silently double-claiming tasks through retry middleware.
+        //
+        // 405 was chosen over 308 Permanent Redirect because RFC 9110 308 preserves
+        // the original request method — a GET-redirected-to-the-same-URL client
+        // would loop, not switch to POST. 405 is the correct semantic for
+        // "wrong method, use this one instead".
+        //
+        // Removal target: next minor release after clients in
+        // data-fabric-client (and any other in-tree consumers) are upgraded.
+        .get_async("/mcp/task/next", |_req, _ctx| async move {
+            worker::console_log!(
+                "WARN: deprecated GET /mcp/task/next called; clients must migrate to POST. \
+                 GET will be removed in the next minor release."
+            );
+            let headers = Headers::new();
+            headers.set("allow", "POST")?;
+            headers.set("deprecation", "true")?;
+            headers.set(
+                "sunset",
+                "GET /mcp/task/next is deprecated; use POST /mcp/task/next",
+            )?;
+            Ok(Response::error(
+                "Method Not Allowed: GET /mcp/task/next is deprecated; use POST /mcp/task/next",
+                405,
+            )?
+            .with_headers(headers))
         })
         .post_async("/mcp/task/:id/heartbeat", |req, ctx| async move {
             let tenant_ctx = tenant::tenant_from_request(&req)?;

--- a/src/models/tests.rs
+++ b/src/models/tests.rs
@@ -1606,3 +1606,140 @@ fn step_type_from_storage_str_falls_back_on_unknown() {
     assert_eq!(StepType::from_storage_str("future_variant"), StepType::Other);
     assert_eq!(StepType::from_storage_str(""), StepType::Other);
 }
+
+// ── OpenAPI contract reconciliation (PR: fix/openapi-spec-reconciliation) ─────
+//
+// The following tests pin the documented response shapes for the three
+// endpoints whose OpenAPI schemas were reconciled with the handlers. They
+// are the canonical guard against silent drift between handler output and
+// the published OpenAPI spec.
+
+/// `/v1/policies/check` returns 9 fields total: 4 always-present and 5
+/// optional ones populated by the policy engine. The OpenAPI schema must
+/// document all 9. This test fixes the typed shape so a follow-up rename
+/// will trip CI before the OpenAPI doc drifts.
+#[test]
+fn policy_check_response_serializes_all_nine_documented_fields() {
+    let resp = PolicyCheckResponse {
+        id: "pd-1".into(),
+        action: "deploy".into(),
+        decision: "allow".into(),
+        reason: "matched rule allow-deploys".into(),
+        risk_level: Some("write".into()),
+        policy_version: Some("v3".into()),
+        matched_rule: Some("rule-deploys".into()),
+        escalation_id: Some("esc-1".into()),
+        rate_limited: Some(false),
+    };
+    let json = serde_json::to_value(&resp).unwrap();
+
+    // Every documented field must serialize, with the documented JSON type.
+    assert!(json["id"].is_string(), "id must be string");
+    assert!(json["action"].is_string(), "action must be string");
+    assert!(json["decision"].is_string(), "decision must be string");
+    assert!(json["reason"].is_string(), "reason must be string");
+    assert!(json["risk_level"].is_string(), "risk_level must be string");
+    assert!(
+        json["policy_version"].is_string(),
+        "policy_version must be string"
+    );
+    assert!(
+        json["matched_rule"].is_string(),
+        "matched_rule must be string"
+    );
+    assert!(
+        json["escalation_id"].is_string(),
+        "escalation_id must be string"
+    );
+    assert!(
+        json["rate_limited"].is_boolean(),
+        "rate_limited must be boolean"
+    );
+
+    // Field count: ensure no undocumented fields slipped in.
+    let object = json.as_object().expect("response must be a JSON object");
+    assert_eq!(
+        object.len(),
+        9,
+        "PolicyCheckResponse must serialize to exactly 9 documented fields, got: {:?}",
+        object.keys().collect::<Vec<_>>()
+    );
+}
+
+/// When the optional fields are `None`, only the 4 required fields serialize
+/// (because of `#[serde(skip_serializing_if = "Option::is_none")]`). The
+/// OpenAPI schema reflects this by marking the 5 extra fields as optional.
+#[test]
+fn policy_check_response_minimal_serializes_only_required_fields() {
+    let resp = PolicyCheckResponse {
+        id: "pd-2".into(),
+        action: "read_secret".into(),
+        decision: "deny".into(),
+        reason: "no rule matched".into(),
+        risk_level: None,
+        policy_version: None,
+        matched_rule: None,
+        escalation_id: None,
+        rate_limited: None,
+    };
+    let json = serde_json::to_value(&resp).unwrap();
+    let object = json.as_object().expect("response must be a JSON object");
+    assert_eq!(
+        object.len(),
+        4,
+        "minimal PolicyCheckResponse must serialize exactly the 4 required fields, got: {:?}",
+        object.keys().collect::<Vec<_>>()
+    );
+    for required in ["id", "action", "decision", "reason"] {
+        assert!(
+            object.contains_key(required),
+            "required field {required} missing"
+        );
+    }
+}
+
+/// `/v1/checkpoints` POST returns `{id, thread_id, state_r2_key}` — clients
+/// need `state_r2_key` to recover state from R2. The OpenAPI schema was
+/// previously misdocumented as `{id, status}`.
+#[test]
+fn checkpoint_created_serializes_all_three_documented_fields() {
+    let cc = CheckpointCreated {
+        id: "cp-1".into(),
+        thread_id: "thread-abc".into(),
+        state_r2_key: "tenant-x/checkpoints/thread-abc/cp-1".into(),
+    };
+    let json = serde_json::to_value(&cc).unwrap();
+    let object = json.as_object().expect("response must be a JSON object");
+    assert_eq!(
+        object.len(),
+        3,
+        "CheckpointCreated must serialize exactly 3 documented fields, got: {:?}",
+        object.keys().collect::<Vec<_>>()
+    );
+    assert!(json["id"].is_string(), "id must be string");
+    assert!(json["thread_id"].is_string(), "thread_id must be string");
+    assert!(
+        json["state_r2_key"].is_string(),
+        "state_r2_key must be string"
+    );
+    // The legacy schema documented a `status` field that the handler never
+    // emitted; assert its absence so re-adding it requires updating the spec.
+    assert!(
+        !object.contains_key("status"),
+        "CheckpointCreated must not include a `status` field (legacy schema drift)"
+    );
+}
+
+/// Round-trip guard: clients deserializing the documented shape must be
+/// able to reconstruct an equal struct. Protects against accidental rename.
+#[test]
+fn checkpoint_created_round_trips_documented_shape() {
+    let original = CheckpointCreated {
+        id: "cp-rt".into(),
+        thread_id: "thread-rt".into(),
+        state_r2_key: "tenant-rt/checkpoints/thread-rt/cp-rt".into(),
+    };
+    let json = serde_json::to_string(&original).unwrap();
+    let parsed: CheckpointCreated = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, parsed);
+}

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,3 +1,116 @@
+#[cfg(test)]
+mod tests {
+    use super::get_openapi_spec;
+
+    fn parse_spec() -> serde_json::Value {
+        serde_json::from_str(get_openapi_spec()).expect("openapi spec must be valid JSON")
+    }
+
+    /// The POST handler for `/v1/policies/check` returns 9 distinct fields.
+    /// The OpenAPI response schema must enumerate every one with the right
+    /// JSON type, or generated clients will silently strip data.
+    #[test]
+    fn openapi_documents_all_nine_policy_check_response_fields() {
+        let spec = parse_spec();
+        let props = &spec["paths"]["/v1/policies/check"]["post"]["responses"]["200"]["content"]
+            ["application/json"]["schema"]["properties"];
+        let expected = [
+            ("id", "string"),
+            ("action", "string"),
+            ("decision", "string"),
+            ("reason", "string"),
+            ("risk_level", "string"),
+            ("policy_version", "string"),
+            ("matched_rule", "string"),
+            ("escalation_id", "string"),
+            ("rate_limited", "boolean"),
+        ];
+        for (name, ty) in expected {
+            assert_eq!(
+                props[name]["type"].as_str(),
+                Some(ty),
+                "/v1/policies/check response must document field `{name}` as type `{ty}`",
+            );
+        }
+        let actual_count = props.as_object().map(|o| o.len()).unwrap_or(0);
+        assert_eq!(
+            actual_count, 9,
+            "/v1/policies/check response must document exactly 9 fields, got {actual_count}",
+        );
+    }
+
+    /// `/v1/checkpoints` POST response: `{id, thread_id, state_r2_key}`. The
+    /// previous schema documented `{id, status}`, which is wrong and breaks
+    /// any client that relies on `state_r2_key` for R2 recovery.
+    #[test]
+    fn openapi_documents_checkpoint_post_response_shape() {
+        let spec = parse_spec();
+        let props = &spec["paths"]["/v1/checkpoints"]["post"]["responses"]["200"]["content"]
+            ["application/json"]["schema"]["properties"];
+        for required in ["id", "thread_id", "state_r2_key"] {
+            assert_eq!(
+                props[required]["type"].as_str(),
+                Some("string"),
+                "/v1/checkpoints response must document field `{required}` as string",
+            );
+        }
+        assert!(
+            props["status"].is_null(),
+            "/v1/checkpoints response must NOT document a `status` field (legacy drift)",
+        );
+        let required = &spec["paths"]["/v1/checkpoints"]["post"]["responses"]["200"]["content"]
+            ["application/json"]["schema"]["required"];
+        let required_set: Vec<&str> = required
+            .as_array()
+            .expect("required must be an array")
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(required_set.contains(&"state_r2_key"));
+        assert!(required_set.contains(&"thread_id"));
+        assert!(required_set.contains(&"id"));
+    }
+
+    /// `/mcp/task/next` is documented under POST. GET is documented as
+    /// deprecated so generated clients warn / log. Confirms HTTP method
+    /// semantics are correct end-to-end (route + spec).
+    #[test]
+    fn openapi_documents_mcp_task_next_as_post_with_deprecated_get() {
+        let spec = parse_spec();
+        let path = &spec["paths"]["/mcp/task/next"];
+        assert!(
+            path["post"].is_object(),
+            "/mcp/task/next must be documented as POST (stateful claim operation)"
+        );
+        // GET kept as a deprecated compatibility shim.
+        let get_op = &path["get"];
+        assert!(
+            get_op.is_object(),
+            "/mcp/task/next GET must remain documented as a deprecation shim"
+        );
+        assert_eq!(
+            get_op["deprecated"].as_bool(),
+            Some(true),
+            "/mcp/task/next GET must be marked deprecated"
+        );
+        assert!(
+            get_op["responses"]["405"].is_object(),
+            "/mcp/task/next GET must document its 405 deprecation response"
+        );
+        // POST must document the required agent_id query parameter so
+        // generated clients carry it forward.
+        let params = path["post"]["parameters"]
+            .as_array()
+            .expect("POST must declare query parameters");
+        let agent_id_param = params
+            .iter()
+            .find(|p| p["name"].as_str() == Some("agent_id"))
+            .expect("POST /mcp/task/next must document `agent_id` parameter");
+        assert_eq!(agent_id_param["required"].as_bool(), Some(true));
+        assert_eq!(agent_id_param["in"].as_str(), Some("query"));
+    }
+}
+
 pub fn get_openapi_spec() -> &'static str {
     r#"{
   "openapi": "3.1.0",
@@ -149,15 +262,18 @@ pub fn get_openapi_spec() -> &'static str {
     "/v1/checkpoints": {
       "post": {
         "summary": "Save Checkpoint",
+        "description": "Persists thread state to R2 and registers a row in D1. The returned state_r2_key is required for downstream R2 recovery and integrity verification.",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["run_id", "state"],
+                "required": ["thread_id", "node_id", "state"],
                 "properties": {
-                  "run_id": { "type": "string" },
+                  "thread_id": { "type": "string" },
+                  "node_id": { "type": "string" },
+                  "parent_id": { "type": "string" },
                   "state": { "type": "object" },
                   "metadata": { "type": "object" }
                 }
@@ -172,9 +288,20 @@ pub fn get_openapi_spec() -> &'static str {
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["id", "thread_id", "state_r2_key"],
                   "properties": {
-                    "id": { "type": "string" },
-                    "status": { "type": "string" }
+                    "id": {
+                      "type": "string",
+                      "description": "Unique checkpoint identifier."
+                    },
+                    "thread_id": {
+                      "type": "string",
+                      "description": "Thread the checkpoint belongs to (echoed from request)."
+                    },
+                    "state_r2_key": {
+                      "type": "string",
+                      "description": "R2 object key where the serialized state was written; required for R2 recovery."
+                    }
                   }
                 }
               }
@@ -292,18 +419,143 @@ pub fn get_openapi_spec() -> &'static str {
         },
         "responses": {
           "200": {
-            "description": "Policy check result",
+            "description": "Policy check result. Fields beyond the four required ones are emitted when the policy engine produces them; clients should treat them as optional but stable.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["id", "action", "decision", "reason"],
                   "properties": {
-                    "id": { "type": "string" },
-                    "action": { "type": "string" },
-                    "decision": { "type": "string", "example": "approved" },
-                    "reason": { "type": "string" }
+                    "id": {
+                      "type": "string",
+                      "description": "Stable policy-decision identifier (audit row id)."
+                    },
+                    "action": {
+                      "type": "string",
+                      "description": "Echo of the action evaluated."
+                    },
+                    "decision": {
+                      "type": "string",
+                      "description": "Verdict: allow, deny, or escalate.",
+                      "example": "allow"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "description": "Human-readable rationale for the verdict."
+                    },
+                    "risk_level": {
+                      "type": "string",
+                      "description": "Lower-cased risk classification: read, write, destructive, or irreversible.",
+                      "example": "write"
+                    },
+                    "policy_version": {
+                      "type": "string",
+                      "description": "Identifier of the policy bundle version that produced this decision."
+                    },
+                    "matched_rule": {
+                      "type": "string",
+                      "description": "Identifier of the specific rule that matched, when one did."
+                    },
+                    "escalation_id": {
+                      "type": "string",
+                      "description": "Set when decision is escalate; identifies the escalation record opened for human review."
+                    },
+                    "rate_limited": {
+                      "type": "boolean",
+                      "description": "True when the decision was influenced by a per-tenant or per-actor rate limit."
+                    }
                   }
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/task/next": {
+      "post": {
+        "summary": "Claim Next Agent Task",
+        "description": "Atomically claims the next pending task for the given agent and capabilities. This is a state-mutating operation: each successful response transfers ownership of a task to the caller. GET is deprecated and will be removed in a future release; existing GET clients receive 405 Method Not Allowed with `Allow: POST`.",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "query",
+            "required": true,
+            "description": "Identifier of the agent claiming the task.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "cap",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of capabilities the agent supports; used to filter eligible tasks.",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Task successfully claimed. Returns the full AgentTask record; memory_context is populated when MOM is configured and relevant memories are found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "job_id",
+                    "task_type",
+                    "priority",
+                    "status",
+                    "retry_count",
+                    "max_retries",
+                    "created_at"
+                  ],
+                  "properties": {
+                    "id": { "type": "string" },
+                    "job_id": { "type": "string" },
+                    "task_type": { "type": "string" },
+                    "priority": { "type": "integer", "format": "int32" },
+                    "status": { "type": "string" },
+                    "params": { "type": "object" },
+                    "result": { "type": "object" },
+                    "agent_id": { "type": "string" },
+                    "graph_ref": { "type": "string" },
+                    "play_id": { "type": "string" },
+                    "parent_task_id": { "type": "string" },
+                    "retry_count": { "type": "integer", "format": "int32" },
+                    "max_retries": { "type": "integer", "format": "int32" },
+                    "lease_expires_at": { "type": "string", "format": "date-time" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "completed_at": { "type": "string", "format": "date-time" },
+                    "memory_context": {
+                      "type": "string",
+                      "description": "Optional MOM-augmented memory context for the agent."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No eligible tasks available for this agent and capability set."
+          },
+          "400": {
+            "description": "Missing required query parameter (agent_id)."
+          }
+        }
+      },
+      "get": {
+        "deprecated": true,
+        "summary": "Claim Next Agent Task (deprecated)",
+        "description": "Deprecated. GET semantics are unsafe for this stateful claim operation because caching proxies may cache claimed state and retry middleware can double-claim. Use POST instead. This endpoint currently returns 405 Method Not Allowed with `Allow: POST`; it will be removed in a future release.",
+        "responses": {
+          "405": {
+            "description": "Method Not Allowed. The `Allow` header advertises the supported method (POST).",
+            "headers": {
+              "Allow": {
+                "schema": { "type": "string", "example": "POST" }
+              },
+              "Deprecation": {
+                "schema": { "type": "string", "example": "true" }
               }
             }
           }


### PR DESCRIPTION
Draft — opened for review before marking ready.

## Why

Addresses three CRITICAL `api_drift` findings raised during the PR #132 crr:

1. **`POST /v1/policies/check` (src/lib.rs:527 + src/openapi.rs)** — handler returns 9 fields; OpenAPI documented only 4. Generated clients silently strip `risk_level`, `policy_version`, `matched_rule`, `escalation_id`, `rate_limited`, hiding signals that downstream consumers (audit pipeline, rate-limit dashboards, escalation router) depend on.
2. **`POST /v1/checkpoints` (src/lib.rs:1101 + src/openapi.rs)** — OpenAPI claimed `{id, status}`; actual handler returns `{id, thread_id, state_r2_key}`. Clients need `state_r2_key` for R2 recovery, and the legacy `status` field never existed on the wire.
3. **`GET /mcp/task/next` (src/lib.rs:746)** — stateful task-claim is non-idempotent and must not be GET. Caching proxies can serve "claimed" state to a second caller; retry middleware that treats GET as safe can double-claim a task.

## What changed (file-by-file)

- **`src/openapi.rs`**
  - `/v1/policies/check` response schema: documents all 9 fields with correct types (`string` x8, `boolean` for `rate_limited`); only the 4 always-present fields are listed as `required` so the spec matches `#[serde(skip_serializing_if = "Option::is_none")]` on the optional fields.
  - `/v1/checkpoints` request body schema: replaced legacy `{run_id, state, metadata}` with the actual `{thread_id, node_id, parent_id?, state, metadata?}` shape consumed by the handler.
  - `/v1/checkpoints` response schema: replaced legacy `{id, status}` with the actual `{id, thread_id, state_r2_key}`, all marked required; each field has a description so generated clients explain why `state_r2_key` matters.
  - `/mcp/task/next` POST: new entry. Documents `agent_id` (required) and `cap` (optional) query parameters, the full `AgentTask` 200 response, 204 (no eligible task), and 400 (missing `agent_id`).
  - `/mcp/task/next` GET: documented with `"deprecated": true` and only a 405 response. Body and headers (`Allow`, `Deprecation`) are spec'd so generated clients show the migration path.
  - Added a test module that asserts the spec round-trips as JSON and that the three reconciled endpoints have the documented shapes — pinning the spec against future drift.
- **`src/lib.rs`**
  - `/mcp/task/next`: handler moved from `.get_async(...)` to `.post_async(...)`; logic is unchanged.
  - New `.get_async("/mcp/task/next", ...)` compatibility shim returns 405 with `Allow: POST`, `Deprecation: true`, and `Sunset: GET /mcp/task/next is deprecated; use POST /mcp/task/next`. Logs a `console_log!` deprecation warning per request so operators can monitor legacy traffic.
  - Inline comment documents the choice of 405 over 308 (RFC 9110 308 preserves the request method, so a GET-to-same-URL redirect would loop, not switch to POST).
  - No business-logic changes to any of the three handlers.
- **`src/models/tests.rs`**
  - Added unit tests pinning the typed response shapes so a future serde rename trips CI before the OpenAPI doc drifts back out of sync.

**Not touched** (per scope): `dfctl/**`, `src/db.rs`, `src/*_do.rs`, `migrations/**`, business logic of the three handlers.

## Tests added

`src/models/tests.rs`:
- `policy_check_response_serializes_all_nine_documented_fields` — asserts every documented field is present with the documented JSON type when all fields are populated, and that exactly 9 fields serialize.
- `policy_check_response_minimal_serializes_only_required_fields` — asserts that when the 5 optional fields are `None`, only the 4 required fields serialize.
- `checkpoint_created_serializes_all_three_documented_fields` — asserts `{id, thread_id, state_r2_key}` all serialize as strings, and that the legacy `status` field is absent.
- `checkpoint_created_round_trips_documented_shape` — round-trip guard against accidental rename of the three fields.

`src/openapi.rs`:
- `openapi_documents_all_nine_policy_check_response_fields` — parses the static spec and asserts every documented field name + type, plus exact field count of 9.
- `openapi_documents_checkpoint_post_response_shape` — asserts `{id, thread_id, state_r2_key}` are all present and required, and that `status` is absent.
- `openapi_documents_mcp_task_next_as_post_with_deprecated_get` — asserts POST is documented with required `agent_id` query parameter, and GET is documented with `deprecated: true` and a 405 response.

## Verification commands run

```
$ RUSTFLAGS="-D warnings" cargo check --target wasm32-unknown-unknown -p data-fabric-worker
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.46s

$ RUSTFLAGS="-D warnings --cfg=coverage" cargo check --tests -p data-fabric-worker
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.04s

$ cargo test -p data-fabric-worker
    test result: ok. 289 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Clean under `-D warnings` for the worker target. All 7 new tests run and pass; full suite (289 tests) green.

## Deprecation timeline for `GET /mcp/task/next`

- **This release**: GET returns 405 `Method Not Allowed` with `Allow: POST`, `Deprecation: true`, `Sunset` header explaining the migration path, plus a per-request `console_log!` warning.
- **Next minor release**: GET handler removed. By then `data-fabric-client::claim_next_task` must use POST.

## Follow-ups required (out of scope)

- **`data-fabric-client/src/lib.rs:206-213` `claim_next_task`** — currently issues `Method::GET` against `/mcp/task/next`. Must be flipped to `Method::POST` before the next minor release; tracked as a follow-up task on the client crate. The client is unaffected by the `PolicyCheckResponse` and `CheckpointCreated` reconciliations because the client struct definitions (`data-fabric-client/src/types.rs:174, 200`) already match the *handler* shape — it was only the OpenAPI spec that was wrong, so no client deserialization breaks here.
- Any other downstream consumers of `GET /mcp/task/next` (out-of-tree agents, dfctl tooling, third-party clients) need the same flip — surfacing them is owned by the rollout track, not this PR.

## Out of scope

- `dfctl` compile fixes — owned by a separate dfctl PR.
- Business logic of any of the three reconciled handlers — owned by the workstream PRs (WS4 policy, M2 checkpoints, M1 task queue); this PR is documentation/method-only.
- Client crate migration for `claim_next_task` GET → POST — see follow-ups above.
- DLQ/observability tuning — already merged in PR #137.