### PR TITLE
fix(ops): pagination on hot list endpoints + pending_tasks backpressure

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -188,15 +188,65 @@ pub async fn register_agent(
     Ok(())
 }
 
-pub async fn list_agents(db: &D1Database, tenant_id: &str) -> Result<Vec<models::Agent>> {
-    let result: D1Result = db
-        .prepare("SELECT * FROM agents WHERE tenant_id = ?1 AND status = 'active' ORDER BY name")
-        .bind(&[JsValue::from_str(tenant_id)])?
-        .all()
-        .await?;
+/// List active agents for `tenant_id` ordered by `(name ASC, id ASC)`.
+///
+/// Returns `(rows, next_cursor)`. Mirrors the `list_runs` pattern: we fetch
+/// `limit + 1` and drop the overflow row to detect the next page without a
+/// second query. The cursor predicate uses an OR of two terms
+/// (`name > ?` OR `name = ? AND id > ?`) rather than a row-value comparison
+/// because SQLite/D1 cannot index `(a, b) > (?, ?)` as a single sargable
+/// expression.
+pub async fn list_agents(
+    db: &D1Database,
+    tenant_id: &str,
+    limit: u32,
+    cursor: Option<&crate::pagination::AgentsCursor>,
+) -> Result<(Vec<models::Agent>, Option<crate::pagination::AgentsCursor>)> {
+    let fetch_limit = limit.saturating_add(1);
 
-    let rows: Vec<AgentRow> = result.results()?;
-    Ok(rows.into_iter().map(|r| r.into_agent()).collect())
+    let mut clauses: Vec<String> =
+        vec!["tenant_id = ?".into(), "status = 'active'".into()];
+    let mut bindings: Vec<JsValue> = vec![JsValue::from_str(tenant_id)];
+
+    if let Some(c) = cursor {
+        clauses.push("(name > ? OR (name = ? AND id > ?))".into());
+        bindings.push(JsValue::from_str(&c.name));
+        bindings.push(JsValue::from_str(&c.name));
+        bindings.push(JsValue::from_str(&c.id));
+    }
+    bindings.push(JsValue::from(fetch_limit));
+
+    let query = format!(
+        "SELECT * FROM agents WHERE {} ORDER BY name ASC, id ASC LIMIT ?",
+        clauses.join(" AND ")
+    );
+
+    let result: D1Result = db.prepare(&query).bind(&bindings)?.all().await?;
+    let mut rows: Vec<AgentRow> = result.results()?;
+
+    let next_cursor = compute_agents_next_cursor(&mut rows, limit);
+
+    Ok((
+        rows.into_iter().map(|r| r.into_agent()).collect(),
+        next_cursor,
+    ))
+}
+
+/// Pure helper: trims the overflow row and produces the cursor for the next
+/// page. Extracted from `list_agents` so it can be unit-tested without D1.
+pub(crate) fn compute_agents_next_cursor(
+    rows: &mut Vec<AgentRow>,
+    limit: u32,
+) -> Option<crate::pagination::AgentsCursor> {
+    if rows.len() as u32 > limit {
+        rows.truncate(limit as usize);
+        rows.last().map(|r| crate::pagination::AgentsCursor {
+            name: r.name.clone(),
+            id: r.id.clone(),
+        })
+    } else {
+        None
+    }
 }
 
 // ── Checkpoints ─────────────────────────────────────────────────
@@ -1644,15 +1694,72 @@ async fn log_retrieval_query(
     Ok(())
 }
 
-pub async fn list_policy_rules(db: &D1Database, tenant_id: &str) -> Result<Vec<PolicyRuleRow>> {
-    let result: D1Result = db
-        .prepare(
-            "SELECT * FROM policy_rules WHERE tenant_id = ?1 ORDER BY priority DESC, created_at ASC",
-        )
-        .bind(&[JsValue::from_str(tenant_id)])?
-        .all()
-        .await?;
-    result.results()
+/// List policy rules for `tenant_id` ordered by
+/// `(priority DESC, created_at ASC, id ASC)`.
+///
+/// Returns `(rows, next_cursor)`. Mirrors the `list_runs` pattern: we fetch
+/// `limit + 1` and drop the overflow row to detect the next page. The cursor
+/// predicate is expressed as a three-level OR over `(priority, created_at, id)`
+/// because SQLite/D1 cannot index a row-value tuple comparison.
+pub async fn list_policy_rules(
+    db: &D1Database,
+    tenant_id: &str,
+    limit: u32,
+    cursor: Option<&crate::pagination::PolicyRulesCursor>,
+) -> Result<(Vec<PolicyRuleRow>, Option<crate::pagination::PolicyRulesCursor>)> {
+    let fetch_limit = limit.saturating_add(1);
+
+    let mut clauses: Vec<String> = vec!["tenant_id = ?".into()];
+    let mut bindings: Vec<JsValue> = vec![JsValue::from_str(tenant_id)];
+
+    if let Some(c) = cursor {
+        // Strict-after predicate on `(priority DESC, created_at ASC, id ASC)`:
+        //   priority < cursor.priority
+        //   OR (priority = cursor.priority AND created_at > cursor.created_at)
+        //   OR (priority = cursor.priority AND created_at = cursor.created_at AND id > cursor.id)
+        clauses.push(
+            "(priority < ? OR (priority = ? AND created_at > ?) OR (priority = ? AND created_at = ? AND id > ?))"
+                .into(),
+        );
+        bindings.push(JsValue::from(c.priority));
+        bindings.push(JsValue::from(c.priority));
+        bindings.push(JsValue::from_str(&c.created_at));
+        bindings.push(JsValue::from(c.priority));
+        bindings.push(JsValue::from_str(&c.created_at));
+        bindings.push(JsValue::from_str(&c.id));
+    }
+    bindings.push(JsValue::from(fetch_limit));
+
+    let query = format!(
+        "SELECT * FROM policy_rules WHERE {} ORDER BY priority DESC, created_at ASC, id ASC LIMIT ?",
+        clauses.join(" AND ")
+    );
+
+    let result: D1Result = db.prepare(&query).bind(&bindings)?.all().await?;
+    let mut rows: Vec<PolicyRuleRow> = result.results()?;
+
+    let next_cursor = compute_policy_rules_next_cursor(&mut rows, limit);
+
+    Ok((rows, next_cursor))
+}
+
+/// Pure helper: trims the overflow row and produces the cursor for the next
+/// page. Extracted from `list_policy_rules` so it can be unit-tested without
+/// D1.
+pub(crate) fn compute_policy_rules_next_cursor(
+    rows: &mut Vec<PolicyRuleRow>,
+    limit: u32,
+) -> Option<crate::pagination::PolicyRulesCursor> {
+    if rows.len() as u32 > limit {
+        rows.truncate(limit as usize);
+        rows.last().map(|r| crate::pagination::PolicyRulesCursor {
+            priority: r.priority,
+            created_at: r.created_at.clone(),
+            id: r.id.clone(),
+        })
+    } else {
+        None
+    }
 }
 
 pub async fn get_policy_rule(
@@ -3698,5 +3805,111 @@ mod tests {
         };
 
         assert!(build_entity_refs(&evt).is_none());
+    }
+
+    // ── Pagination helpers: list_policy_rules / list_agents ─────
+
+    fn agent_row(id: &str, name: &str) -> AgentRow {
+        AgentRow {
+            id: id.into(),
+            name: name.into(),
+            capabilities: "[]".into(),
+            endpoint: None,
+            last_heartbeat: None,
+            status: "active".into(),
+            metadata: None,
+        }
+    }
+
+    fn policy_row(id: &str, priority: i32, created_at: &str) -> PolicyRuleRow {
+        PolicyRuleRow {
+            id: id.into(),
+            name: format!("rule-{id}"),
+            action_pattern: "*".into(),
+            resource_pattern: "*".into(),
+            actor_pattern: "*".into(),
+            risk_level: "read".into(),
+            verdict: "allow".into(),
+            reason: "test".into(),
+            priority,
+            enabled: 1,
+            created_at: created_at.into(),
+            updated_at: created_at.into(),
+        }
+    }
+
+    #[test]
+    fn list_agents_helper_returns_no_cursor_when_results_under_limit() {
+        let mut rows = vec![agent_row("a1", "alpha"), agent_row("a2", "beta")];
+        let cursor = compute_agents_next_cursor(&mut rows, 5);
+        assert!(cursor.is_none());
+        assert_eq!(rows.len(), 2, "rows preserved when under limit");
+    }
+
+    #[test]
+    fn list_agents_helper_returns_no_cursor_when_results_exactly_at_limit() {
+        // Exactly `limit` rows means no overflow row was fetched -> no next.
+        let mut rows = vec![agent_row("a1", "alpha"), agent_row("a2", "beta")];
+        let cursor = compute_agents_next_cursor(&mut rows, 2);
+        assert!(cursor.is_none());
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn list_agents_helper_trims_overflow_and_returns_cursor() {
+        // limit=2 with 3 rows: the third is the overflow probe; should be
+        // dropped, and the cursor is built from the last *returned* row.
+        let mut rows = vec![
+            agent_row("a1", "alpha"),
+            agent_row("a2", "beta"),
+            agent_row("a3", "gamma"),
+        ];
+        let cursor = compute_agents_next_cursor(&mut rows, 2).expect("cursor");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(cursor.name, "beta");
+        assert_eq!(cursor.id, "a2");
+    }
+
+    #[test]
+    fn list_policy_rules_helper_returns_no_cursor_when_results_under_limit() {
+        let mut rows = vec![
+            policy_row("r1", 100, "2026-01-01T00:00:00Z"),
+            policy_row("r2", 50, "2026-01-02T00:00:00Z"),
+        ];
+        let cursor = compute_policy_rules_next_cursor(&mut rows, 5);
+        assert!(cursor.is_none());
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn list_policy_rules_helper_trims_overflow_and_returns_cursor() {
+        let mut rows = vec![
+            policy_row("r1", 100, "2026-01-01T00:00:00Z"),
+            policy_row("r2", 50, "2026-01-02T00:00:00Z"),
+            policy_row("r3", 25, "2026-01-03T00:00:00Z"),
+        ];
+        let cursor = compute_policy_rules_next_cursor(&mut rows, 2).expect("cursor");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(cursor.priority, 50);
+        assert_eq!(cursor.created_at, "2026-01-02T00:00:00Z");
+        assert_eq!(cursor.id, "r2");
+    }
+
+    #[test]
+    fn list_policy_rules_helper_preserves_order_after_truncation() {
+        // The returned rows must remain in caller-visible order; truncation
+        // removes the overflow probe from the *end*, not from the middle.
+        let mut rows = vec![
+            policy_row("r1", 100, "2026-01-01T00:00:00Z"),
+            policy_row("r2", 100, "2026-01-02T00:00:00Z"),
+            policy_row("r3", 50, "2026-01-03T00:00:00Z"),
+        ];
+        let cursor = compute_policy_rules_next_cursor(&mut rows, 2).expect("cursor");
+        assert_eq!(rows[0].id, "r1");
+        assert_eq!(rows[1].id, "r2");
+        // Cursor reflects the last *returned* row, breaking the priority tie
+        // on (created_at, id).
+        assert_eq!(cursor.priority, 100);
+        assert_eq!(cursor.id, "r2");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -768,7 +768,16 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                     ..Default::default()
                 },
             )?;
-            stub.fetch_with_request(do_req).await?;
+            let do_resp = stub.fetch_with_request(do_req).await?;
+
+            // Propagate any non-2xx response (notably 429 QUEUE_FULL backpressure
+            // from TaskLeaseManager when pending_tasks is at MAX_PENDING_TASKS)
+            // to the client. Without this passthrough, the DO's Retry-After +
+            // QUEUE_FULL envelope is silently swallowed and the client sees a
+            // generic success / 500, defeating the backpressure feature.
+            if let Some(forwarded) = forward_do_response(do_resp).await? {
+                return Ok(forwarded);
+            }
 
             Response::from_json(&models::TaskCreated {
                 id,
@@ -2072,6 +2081,86 @@ async fn ingest_events_bronze_silver(
     Ok(count)
 }
 
+/// Decision for how to handle a Durable Object response from the worker
+/// handler. Pure so the routing rule is unit-testable without a wasm runtime.
+#[derive(Debug, PartialEq, Eq)]
+enum DoForwardAction {
+    /// 2xx — handler should proceed with its normal success path.
+    Success,
+    /// Non-2xx — handler should mirror this status back to the client. For
+    /// 429 the DO's `retry-after` header is preserved (defaulting to
+    /// `DEFAULT_DO_RETRY_AFTER_SECS` when absent), so the backpressure
+    /// contract surfaces end-to-end.
+    Forward {
+        status: u16,
+        retry_after: Option<String>,
+    },
+}
+
+/// Default Retry-After value to apply when the DO returned 429 without a
+/// `retry-after` header. Matches the TaskLeaseManager `/enqueue` 30s value
+/// so a missing header doesn't downgrade the client-visible contract.
+const DEFAULT_DO_RETRY_AFTER_SECS: u32 = 30;
+
+/// Classify a DO response status + retry-after header into a forward action.
+/// Pure: takes primitives so it's testable without a JS runtime.
+fn classify_do_response(status: u16, retry_after_header: Option<&str>) -> DoForwardAction {
+    if (200..300).contains(&status) {
+        DoForwardAction::Success
+    } else {
+        let retry_after = if status == 429 {
+            Some(
+                retry_after_header
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| DEFAULT_DO_RETRY_AFTER_SECS.to_string()),
+            )
+        } else {
+            retry_after_header.map(|s| s.to_string())
+        };
+        DoForwardAction::Forward { status, retry_after }
+    }
+}
+
+/// Forward a Durable Object response back to the client when it carries a
+/// non-2xx status. Returns `Ok(None)` for 2xx so callers continue with their
+/// success path; returns `Ok(Some(resp))` with the status, retry-after, and
+/// body mirrored when the DO signaled backpressure or another error.
+///
+/// This exists because `stub.fetch_with_request(...).await?` swallows the DO
+/// response by default — including the 429 `QUEUE_FULL` envelope from
+/// TaskLeaseManager — so without explicit propagation the client sees a
+/// generic success (or, worse, a 500) and the backpressure feature is mute.
+async fn forward_do_response(mut do_resp: Response) -> Result<Option<Response>> {
+    let status = do_resp.status_code();
+    let retry_after = do_resp
+        .headers()
+        .get("retry-after")
+        .ok()
+        .flatten();
+    match classify_do_response(status, retry_after.as_deref()) {
+        DoForwardAction::Success => Ok(None),
+        DoForwardAction::Forward { status, retry_after } => {
+            let content_type = do_resp
+                .headers()
+                .get("content-type")
+                .ok()
+                .flatten()
+                .unwrap_or_else(|| "application/json".to_string());
+            let body = do_resp.bytes().await.unwrap_or_default();
+
+            let headers = Headers::new();
+            headers.set("content-type", &content_type)?;
+            if let Some(value) = retry_after {
+                headers.set("retry-after", &value)?;
+            }
+            let resp = Response::from_bytes(body)?
+                .with_status(status)
+                .with_headers(headers);
+            Ok(Some(resp))
+        }
+    }
+}
+
 /// Build a 503 response for graceful degradation when the fabric is unavailable.
 /// Used by integration intake handlers to signal temporary unavailability
 /// so clients can retry rather than treating the failure as permanent.
@@ -2130,9 +2219,103 @@ fn build_trace_response_metadata(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_trace_response_metadata, parse_limit_query, parse_limit_query_with_valid_presence,
+        build_trace_response_metadata, classify_do_response, parse_limit_query,
+        parse_limit_query_with_valid_presence, DoForwardAction, DEFAULT_DO_RETRY_AFTER_SECS,
     };
     use worker::Url;
+
+    // ── classify_do_response (DO 429 / error forwarding) ────────
+
+    #[test]
+    fn classify_do_response_passes_2xx_as_success() {
+        // 2xx codes must not be forwarded — handler proceeds with its
+        // normal success path. This is the only "Success" branch.
+        for status in [200u16, 201, 202, 204, 299] {
+            assert_eq!(
+                classify_do_response(status, None),
+                DoForwardAction::Success,
+                "status {status} should be classified as Success",
+            );
+        }
+    }
+
+    #[test]
+    fn classify_do_response_forwards_429_with_do_retry_after() {
+        // When the DO sets retry-after explicitly, that exact value is
+        // mirrored back to the client. This is the TaskLeaseManager
+        // backpressure contract surfaced end-to-end.
+        let action = classify_do_response(429, Some("30"));
+        assert_eq!(
+            action,
+            DoForwardAction::Forward {
+                status: 429,
+                retry_after: Some("30".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn classify_do_response_429_without_header_defaults_retry_after() {
+        // Defensive: if a future DO omits retry-after on 429, the worker
+        // still surfaces a sensible default so clients don't hot-loop.
+        let action = classify_do_response(429, None);
+        assert_eq!(
+            action,
+            DoForwardAction::Forward {
+                status: 429,
+                retry_after: Some(DEFAULT_DO_RETRY_AFTER_SECS.to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn classify_do_response_forwards_other_4xx_without_synthesizing_retry_after() {
+        // Non-429 4xx errors pass through with whatever (if any)
+        // retry-after the DO sent — we don't fabricate one.
+        assert_eq!(
+            classify_do_response(404, None),
+            DoForwardAction::Forward {
+                status: 404,
+                retry_after: None,
+            },
+        );
+        assert_eq!(
+            classify_do_response(400, Some("5")),
+            DoForwardAction::Forward {
+                status: 400,
+                retry_after: Some("5".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn classify_do_response_forwards_5xx() {
+        // 5xx from a DO is forwarded as-is so operators see the real
+        // failure mode instead of an opaque worker 500.
+        assert_eq!(
+            classify_do_response(500, None),
+            DoForwardAction::Forward {
+                status: 500,
+                retry_after: None,
+            },
+        );
+        assert_eq!(
+            classify_do_response(503, Some("60")),
+            DoForwardAction::Forward {
+                status: 503,
+                retry_after: Some("60".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn classify_do_response_default_retry_after_matches_task_lease_manager() {
+        // Tripwire: the default must match the TaskLeaseManager
+        // ENQUEUE_RETRY_AFTER_SECS value (30) so a missing header
+        // doesn't downgrade the contract.
+        assert_eq!(DEFAULT_DO_RETRY_AFTER_SECS, 30);
+        assert_eq!(DEFAULT_DO_RETRY_AFTER_SECS, super::task_do::ENQUEUE_RETRY_AFTER_SECS);
+    }
 
     #[test]
     fn parse_limit_query_parses_valid_value() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2085,12 +2085,16 @@ async fn ingest_events_bronze_silver(
 /// handler. Pure so the routing rule is unit-testable without a wasm runtime.
 #[derive(Debug, PartialEq, Eq)]
 enum DoForwardAction {
-    /// 2xx — handler should proceed with its normal success path.
+    /// 2xx or 3xx — handler should proceed with its normal success path.
+    /// 3xx is included so a future DO update that emits a redirect isn't
+    /// surfaced as a synthetic gateway error.
     Success,
-    /// Non-2xx — handler should mirror this status back to the client. For
-    /// 429 the DO's `retry-after` header is preserved (defaulting to
-    /// `DEFAULT_DO_RETRY_AFTER_SECS` when absent), so the backpressure
-    /// contract surfaces end-to-end.
+    /// 4xx/5xx — handler should mirror this status back to the client.
+    /// For 429 the DO's `retry-after` is preserved through
+    /// [`sanitize_retry_after`] (defaulting to
+    /// `DEFAULT_DO_RETRY_AFTER_SECS` when absent or malformed) so the
+    /// backpressure contract surfaces end-to-end. For other non-2xx/3xx
+    /// statuses the header is only forwarded when syntactically valid.
     Forward {
         status: u16,
         retry_after: Option<String>,
@@ -2102,20 +2106,92 @@ enum DoForwardAction {
 /// so a missing header doesn't downgrade the client-visible contract.
 const DEFAULT_DO_RETRY_AFTER_SECS: u32 = 30;
 
+/// Validate a `retry-after` header value per RFC 7231 §7.1.3 and return a
+/// non-negative integer delta-seconds value. Accepts either:
+///   * a non-negative integer (delta-seconds form), or
+///   * an HTTP-date (IMF-fixdate / RFC 850 / asctime per RFC 7231 §7.1.1.1).
+///
+/// Garbage (or absent) input falls back to [`DEFAULT_DO_RETRY_AFTER_SECS`] so
+/// we never forward an invalid header to the client. The output is always
+/// expressed in seconds — for the HTTP-date form we use the default rather
+/// than parsing the timestamp (we lack a date dep and the DO contract is
+/// to emit delta-seconds), but we still accept the date form as syntactically
+/// valid so a conformant peer is not rejected.
+fn sanitize_retry_after(raw: Option<&str>) -> u32 {
+    let Some(value) = raw.map(str::trim).filter(|s| !s.is_empty()) else {
+        return DEFAULT_DO_RETRY_AFTER_SECS;
+    };
+    if let Ok(secs) = value.parse::<u32>() {
+        return secs;
+    }
+    if looks_like_http_date(value) {
+        // Accept as valid per RFC 7231, but normalise to the default
+        // because we don't carry a date-parsing dep in the worker.
+        return DEFAULT_DO_RETRY_AFTER_SECS;
+    }
+    DEFAULT_DO_RETRY_AFTER_SECS
+}
+
+/// Cheap structural check for an RFC 7231 §7.1.1.1 HTTP-date. Recognises
+/// the three permitted forms by their leading weekday token plus a
+/// trailing time component (HH:MM:SS). Intentionally tolerant — the goal
+/// is to distinguish well-formed HTTP-date strings from garbage, not to
+/// fully parse the timestamp.
+fn looks_like_http_date(s: &str) -> bool {
+    const WEEKDAYS_SHORT: [&str; 7] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+    const WEEKDAYS_LONG: [&str; 7] = [
+        "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+    ];
+    // Length sanity — shortest legal form (asctime: "Sun Nov  6 08:49:37 1994") is 24 chars;
+    // longest legal form (RFC 850 with "Wednesday") is around 33 chars. Allow some slack.
+    if s.len() < 20 || s.len() > 40 {
+        return false;
+    }
+    let starts_with_weekday = WEEKDAYS_SHORT
+        .iter()
+        .chain(WEEKDAYS_LONG.iter())
+        .any(|wd| s.starts_with(wd));
+    if !starts_with_weekday {
+        return false;
+    }
+    // Must contain a time-of-day "HH:MM:SS" — two colons separating digits.
+    let colon_count = s.bytes().filter(|&b| b == b':').count();
+    colon_count == 2
+}
+
 /// Classify a DO response status + retry-after header into a forward action.
 /// Pure: takes primitives so it's testable without a JS runtime.
+///
+/// The success range is `(200..400)` rather than `(200..300)` so that any
+/// 3xx redirect emitted by a (future) DO update is treated as a normal
+/// pass-through. Gateways shouldn't surface a downstream redirect as an
+/// error, and DOs in this worker don't intentionally redirect today.
+///
+/// Any `retry-after` header on a forwarded (non-2xx, non-3xx) response is
+/// sanitised through [`sanitize_retry_after`] so a malformed value from
+/// the DO can't propagate to clients.
 fn classify_do_response(status: u16, retry_after_header: Option<&str>) -> DoForwardAction {
-    if (200..300).contains(&status) {
+    if (200..400).contains(&status) {
         DoForwardAction::Success
     } else {
         let retry_after = if status == 429 {
-            Some(
-                retry_after_header
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| DEFAULT_DO_RETRY_AFTER_SECS.to_string()),
-            )
+            // 429 always carries a retry-after — synthesize the default
+            // when the DO omitted (or garbled) the header.
+            Some(sanitize_retry_after(retry_after_header).to_string())
         } else {
-            retry_after_header.map(|s| s.to_string())
+            // Other 4xx/5xx: only forward retry-after if the DO actually
+            // provided a syntactically valid value. We don't synthesize a
+            // default outside the 429 backpressure contract.
+            retry_after_header.and_then(|raw| {
+                let trimmed = raw.trim();
+                if trimmed.is_empty() {
+                    None
+                } else if trimmed.parse::<u32>().is_ok() || looks_like_http_date(trimmed) {
+                    Some(trimmed.to_string())
+                } else {
+                    None
+                }
+            })
         };
         DoForwardAction::Forward { status, retry_after }
     }
@@ -2220,7 +2296,8 @@ fn build_trace_response_metadata(
 mod tests {
     use super::{
         build_trace_response_metadata, classify_do_response, parse_limit_query,
-        parse_limit_query_with_valid_presence, DoForwardAction, DEFAULT_DO_RETRY_AFTER_SECS,
+        parse_limit_query_with_valid_presence, sanitize_retry_after, DoForwardAction,
+        DEFAULT_DO_RETRY_AFTER_SECS,
     };
     use worker::Url;
 
@@ -2315,6 +2392,111 @@ mod tests {
         // doesn't downgrade the contract.
         assert_eq!(DEFAULT_DO_RETRY_AFTER_SECS, 30);
         assert_eq!(DEFAULT_DO_RETRY_AFTER_SECS, super::task_do::ENQUEUE_RETRY_AFTER_SECS);
+    }
+
+    #[test]
+    fn classify_do_response_passes_through_3xx() {
+        // 3xx redirect codes are not errors and must not be forwarded
+        // through the error-mirroring path. DOs in this worker don't
+        // intentionally redirect today, but a future update that does
+        // shouldn't surface as a synthetic worker error.
+        for status in [300u16, 301, 302, 303, 304, 307, 308, 399] {
+            assert_eq!(
+                classify_do_response(status, None),
+                DoForwardAction::Success,
+                "status {status} should pass through as Success",
+            );
+        }
+        // Even with a retry-after header set, 3xx still passes through:
+        // the redirect semantics take precedence over backpressure.
+        assert_eq!(
+            classify_do_response(302, Some("5")),
+            DoForwardAction::Success,
+        );
+    }
+
+    #[test]
+    fn sanitize_retry_after_rejects_garbage() {
+        // Numeric delta-seconds — accepted verbatim.
+        assert_eq!(sanitize_retry_after(Some("0")), 0);
+        assert_eq!(sanitize_retry_after(Some("30")), 30);
+        assert_eq!(sanitize_retry_after(Some("3600")), 3600);
+        // Leading/trailing whitespace is normalised.
+        assert_eq!(sanitize_retry_after(Some("  42  ")), 42);
+
+        // HTTP-date forms (RFC 7231 §7.1.1.1) — accepted as syntactically
+        // valid; normalised to the default because we don't carry a date
+        // dep. The point is they are NOT treated as garbage.
+        assert_eq!(
+            sanitize_retry_after(Some("Sun, 06 Nov 1994 08:49:37 GMT")),
+            DEFAULT_DO_RETRY_AFTER_SECS,
+        );
+        assert_eq!(
+            sanitize_retry_after(Some("Sunday, 06-Nov-94 08:49:37 GMT")),
+            DEFAULT_DO_RETRY_AFTER_SECS,
+        );
+
+        // Garbage — falls back to default rather than forwarding to client.
+        for garbage in [
+            "",                              // empty
+            "   ",                           // whitespace-only
+            "soon",                          // arbitrary token
+            "-5",                            // negative (rejected by u32 parse)
+            "30.5",                          // fractional
+            "30s",                           // unit-suffixed
+            "9999999999",                    // overflows u32
+            "0x1e",                          // hex
+            "\u{0007}garbage\u{0007}",       // control chars
+            "Notaday, 06 Nov 1994 08:49:37", // bogus weekday
+            "Sun 06 Nov 1994",               // missing time component
+        ] {
+            assert_eq!(
+                sanitize_retry_after(Some(garbage)),
+                DEFAULT_DO_RETRY_AFTER_SECS,
+                "garbage value {garbage:?} should fall back to default",
+            );
+        }
+
+        // Absent header — falls back to default.
+        assert_eq!(
+            sanitize_retry_after(None),
+            DEFAULT_DO_RETRY_AFTER_SECS,
+        );
+    }
+
+    #[test]
+    fn classify_do_response_drops_garbage_retry_after_on_non_429() {
+        // Non-429 errors must not propagate a malformed retry-after value
+        // to the client. We drop the header rather than synthesizing a
+        // default (which only applies to the 429 backpressure contract).
+        assert_eq!(
+            classify_do_response(503, Some("not-a-number")),
+            DoForwardAction::Forward {
+                status: 503,
+                retry_after: None,
+            },
+        );
+        // Valid integer is preserved as-is.
+        assert_eq!(
+            classify_do_response(503, Some("60")),
+            DoForwardAction::Forward {
+                status: 503,
+                retry_after: Some("60".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn classify_do_response_sanitizes_garbage_retry_after_on_429() {
+        // 429 with a garbage retry-after must be replaced with the default
+        // — the client must never see invalid header content.
+        assert_eq!(
+            classify_do_response(429, Some("forever")),
+            DoForwardAction::Forward {
+                status: 429,
+                retry_after: Some(DEFAULT_DO_RETRY_AFTER_SECS.to_string()),
+            },
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,10 +565,42 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         })
         .get_async("/v1/policies/rules", |req, ctx| async move {
             let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let url = req.url()?;
+            let params: std::collections::HashMap<String, String> = url
+                .query_pairs()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            let limit = pagination::clamp_limit(params.get("limit").and_then(|s| s.parse().ok()));
+            let cursor = match pagination::PolicyRulesCursor::decode(
+                params.get("cursor").map(|s| s.as_str()),
+            ) {
+                Ok(c) => c,
+                Err(_) => {
+                    return errors::error_response(
+                        "INVALID_CURSOR",
+                        "cursor is malformed; echo back the next_cursor from a prior response",
+                        400,
+                    );
+                }
+            };
             let d1 = ctx.env.d1("DB")?;
-            let rules = db::list_policy_rules(&d1, &tenant_ctx.tenant_id).await?;
+            let (rules, next_cursor) =
+                db::list_policy_rules(&d1, &tenant_ctx.tenant_id, limit, cursor.as_ref()).await?;
+            let next_cursor_str = match next_cursor.as_ref().map(|c| c.encode()).transpose() {
+                Ok(s) => s,
+                Err(_) => {
+                    return errors::error_response(
+                        "CURSOR_ENCODE_FAILED",
+                        "internal: failed to encode next cursor",
+                        500,
+                    );
+                }
+            };
             let responses: Vec<_> = rules.into_iter().map(|r| r.into_response()).collect();
-            Response::from_json(&serde_json::json!({ "rules": responses }))
+            Response::from_json(&serde_json::json!({
+                "rules": responses,
+                "next_cursor": next_cursor_str,
+            }))
         })
         .get_async("/v1/policies/rules/:id", |req, ctx| async move {
             let tenant_ctx = tenant::tenant_from_request(&req)?;
@@ -898,9 +930,41 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         })
         .get_async("/v1/agents", |req, ctx| async move {
             let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let url = req.url()?;
+            let params: std::collections::HashMap<String, String> = url
+                .query_pairs()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            let limit = pagination::clamp_limit(params.get("limit").and_then(|s| s.parse().ok()));
+            let cursor = match pagination::AgentsCursor::decode(
+                params.get("cursor").map(|s| s.as_str()),
+            ) {
+                Ok(c) => c,
+                Err(_) => {
+                    return errors::error_response(
+                        "INVALID_CURSOR",
+                        "cursor is malformed; echo back the next_cursor from a prior response",
+                        400,
+                    );
+                }
+            };
             let d1 = ctx.env.d1("DB")?;
-            let agents = db::list_agents(&d1, &tenant_ctx.tenant_id).await?;
-            Response::from_json(&serde_json::json!({ "agents": agents }))
+            let (agents, next_cursor) =
+                db::list_agents(&d1, &tenant_ctx.tenant_id, limit, cursor.as_ref()).await?;
+            let next_cursor_str = match next_cursor.as_ref().map(|c| c.encode()).transpose() {
+                Ok(s) => s,
+                Err(_) => {
+                    return errors::error_response(
+                        "CURSOR_ENCODE_FAILED",
+                        "internal: failed to encode next cursor",
+                        500,
+                    );
+                }
+            };
+            Response::from_json(&serde_json::json!({
+                "agents": agents,
+                "next_cursor": next_cursor_str,
+            }))
         })
         .post_async("/v1/telemetry", |mut req, ctx| async move {
             let body: models::TelemetrySnapshot = req.json().await?;

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -9,6 +9,11 @@
 //! For `/v1/runs` the sort key is `(created_at DESC, id DESC)`, so the cursor
 //! carries both fields. Including `id` breaks ties when two runs share the
 //! same `created_at`.
+//!
+//! `/v1/policies/rules` and `/v1/agents` follow the same shape: the cursor
+//! carries the row's primary sort field plus `id` as a tiebreaker. All cursor
+//! types use single-letter serde keys (`c`, `i`, `n`, `p`) to keep the
+//! hex-encoded payload short — clients still get a single opaque blob.
 
 use serde::{Deserialize, Serialize};
 use worker::Result;
@@ -35,6 +40,76 @@ impl RunsCursor {
     /// Decode a hex-encoded cursor. Returns `Ok(None)` if the input is empty,
     /// `Err` if the input is present but malformed (callers should map this
     /// to `INVALID_CURSOR` 400).
+    pub fn decode(raw: Option<&str>) -> Result<Option<Self>> {
+        let Some(raw) = raw.filter(|s| !s.is_empty()) else {
+            return Ok(None);
+        };
+        let bytes = hex::decode(raw)
+            .map_err(|e| worker::Error::RustError(format!("decode cursor hex: {e}")))?;
+        let cursor: Self = serde_json::from_slice(&bytes)
+            .map_err(|e| worker::Error::RustError(format!("decode cursor json: {e}")))?;
+        Ok(Some(cursor))
+    }
+}
+
+/// Sort-key tuple for `/v1/policies/rules` pagination.
+///
+/// Rows are ordered by `(priority DESC, created_at ASC, id ASC)`. Carrying all
+/// three fields lets the query resume deterministically even when many rules
+/// share the same `priority` and `created_at` (common when seeded in batches).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PolicyRulesCursor {
+    /// Last row's `priority`.
+    #[serde(rename = "p")]
+    pub priority: i32,
+    /// Last row's `created_at` (ISO 8601 string from D1).
+    #[serde(rename = "c")]
+    pub created_at: String,
+    /// Last row's `id`, used as a final tiebreaker.
+    #[serde(rename = "i")]
+    pub id: String,
+}
+
+impl PolicyRulesCursor {
+    pub fn encode(&self) -> Result<String> {
+        let json = serde_json::to_vec(self)
+            .map_err(|e| worker::Error::RustError(format!("encode cursor: {e}")))?;
+        Ok(hex::encode(json))
+    }
+
+    pub fn decode(raw: Option<&str>) -> Result<Option<Self>> {
+        let Some(raw) = raw.filter(|s| !s.is_empty()) else {
+            return Ok(None);
+        };
+        let bytes = hex::decode(raw)
+            .map_err(|e| worker::Error::RustError(format!("decode cursor hex: {e}")))?;
+        let cursor: Self = serde_json::from_slice(&bytes)
+            .map_err(|e| worker::Error::RustError(format!("decode cursor json: {e}")))?;
+        Ok(Some(cursor))
+    }
+}
+
+/// Sort-key tuple for `/v1/agents` pagination.
+///
+/// Rows are ordered by `(name ASC, id ASC)`. Carrying `id` breaks ties for
+/// agents that share a name (rare but possible across capability variants).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentsCursor {
+    /// Last row's `name`.
+    #[serde(rename = "n")]
+    pub name: String,
+    /// Last row's `id`, used as a tiebreaker.
+    #[serde(rename = "i")]
+    pub id: String,
+}
+
+impl AgentsCursor {
+    pub fn encode(&self) -> Result<String> {
+        let json = serde_json::to_vec(self)
+            .map_err(|e| worker::Error::RustError(format!("encode cursor: {e}")))?;
+        Ok(hex::encode(json))
+    }
+
     pub fn decode(raw: Option<&str>) -> Result<Option<Self>> {
         let Some(raw) = raw.filter(|s| !s.is_empty()) else {
             return Ok(None);
@@ -95,5 +170,60 @@ mod tests {
         assert_eq!(clamp_limit(Some(10)), 10);
         assert_eq!(clamp_limit(Some(0)), 1);
         assert_eq!(clamp_limit(Some(5_000)), MAX_PAGE_LIMIT);
+    }
+
+    // ── PolicyRulesCursor ──────────────────────────────────────
+
+    #[test]
+    fn policy_rules_cursor_roundtrips_through_hex() {
+        let cursor = PolicyRulesCursor {
+            priority: 100,
+            created_at: "2026-05-13T10:00:00Z".into(),
+            id: "rule-abc".into(),
+        };
+        let encoded = cursor.encode().expect("encode");
+        let decoded = PolicyRulesCursor::decode(Some(&encoded))
+            .expect("decode")
+            .expect("some");
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn policy_rules_cursor_decode_returns_none_for_absent_or_empty() {
+        assert!(PolicyRulesCursor::decode(None).unwrap().is_none());
+        assert!(PolicyRulesCursor::decode(Some("")).unwrap().is_none());
+    }
+
+    #[test]
+    fn policy_rules_cursor_decode_errors_on_garbage() {
+        assert!(PolicyRulesCursor::decode(Some("not-hex-zzzz")).is_err());
+        assert!(PolicyRulesCursor::decode(Some("deadbeef")).is_err());
+    }
+
+    // ── AgentsCursor ───────────────────────────────────────────
+
+    #[test]
+    fn agents_cursor_roundtrips_through_hex() {
+        let cursor = AgentsCursor {
+            name: "agent-orchestrator".into(),
+            id: "ag-42".into(),
+        };
+        let encoded = cursor.encode().expect("encode");
+        let decoded = AgentsCursor::decode(Some(&encoded))
+            .expect("decode")
+            .expect("some");
+        assert_eq!(decoded, cursor);
+    }
+
+    #[test]
+    fn agents_cursor_decode_returns_none_for_absent_or_empty() {
+        assert!(AgentsCursor::decode(None).unwrap().is_none());
+        assert!(AgentsCursor::decode(Some("")).unwrap().is_none());
+    }
+
+    #[test]
+    fn agents_cursor_decode_errors_on_garbage() {
+        assert!(AgentsCursor::decode(Some("not-hex-zzzz")).is_err());
+        assert!(AgentsCursor::decode(Some("deadbeef")).is_err());
     }
 }

--- a/src/task_do.rs
+++ b/src/task_do.rs
@@ -10,6 +10,41 @@ struct TaskLeaseState {
     active_tasks: std::collections::HashMap<String, AgentTask>,
 }
 
+/// Maximum number of pending tasks held in a single TaskLeaseManager DO.
+///
+/// Chosen to bound DO storage growth when producers outrun consumers. With an
+/// average serialized `AgentTask` of ~2 KB, 10k pending tasks corresponds to
+/// roughly 20 MB of DO storage — well under the per-DO storage limits but
+/// enough to absorb a normal burst. Tunable; revisit if real workloads
+/// regularly hit the cap.
+pub const MAX_PENDING_TASKS: usize = 10_000;
+
+/// Storage key for the cumulative count of enqueue requests rejected due to
+/// backpressure. Surfaced later via a `/metrics` endpoint (not in this PR).
+pub const PENDING_REJECTED_TOTAL_KEY: &str = "pending_rejected_total";
+
+/// Retry-After value (seconds) returned alongside 429 from `/enqueue` when the
+/// queue is at capacity. 30s gives consumers time to drain a meaningful chunk
+/// without leaving producers idle for too long.
+pub const ENQUEUE_RETRY_AFTER_SECS: u32 = 30;
+
+/// Pure decision: should this enqueue be accepted, given the current queue
+/// length and the configured maximum? Extracted so the backpressure rule can
+/// be unit-tested without the wasm runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnqueueDecision {
+    Accept,
+    Reject,
+}
+
+pub fn enqueue_decision(current_len: usize, max: usize) -> EnqueueDecision {
+    if current_len >= max {
+        EnqueueDecision::Reject
+    } else {
+        EnqueueDecision::Accept
+    }
+}
+
 #[durable_object]
 pub struct TaskLeaseManager {
     state: State,
@@ -30,11 +65,45 @@ impl DurableObject for TaskLeaseManager {
             (Method::Post, "/enqueue") => {
                 let task: AgentTask = req.json().await?;
                 let storage = self.state.storage();
-                
+
                 let mut pending: VecDeque<AgentTask> = storage.get("pending").await.ok().flatten().unwrap_or_default();
+
+                // Backpressure: reject before deserialization-heavy work piles
+                // up. Counter persists across requests so operators can see
+                // sustained pressure via a future /metrics endpoint.
+                if enqueue_decision(pending.len(), MAX_PENDING_TASKS)
+                    == EnqueueDecision::Reject
+                {
+                    let prev_rejected: u64 = storage
+                        .get(PENDING_REJECTED_TOTAL_KEY)
+                        .await
+                        .ok()
+                        .flatten()
+                        .unwrap_or(0);
+                    let next_rejected = prev_rejected.saturating_add(1);
+                    storage.put(PENDING_REJECTED_TOTAL_KEY, next_rejected).await?;
+
+                    let headers = Headers::new();
+                    headers.set("retry-after", &ENQUEUE_RETRY_AFTER_SECS.to_string())?;
+                    headers.set("content-type", "application/json")?;
+                    let body = serde_json::json!({
+                        "error": {
+                            "code": "QUEUE_FULL",
+                            "message": "pending_tasks queue at capacity; retry after the indicated delay",
+                            "details": {
+                                "max_pending_tasks": MAX_PENDING_TASKS,
+                                "retry_after_seconds": ENQUEUE_RETRY_AFTER_SECS,
+                            }
+                        }
+                    });
+                    return Ok(Response::from_json(&body)?
+                        .with_status(429)
+                        .with_headers(headers));
+                }
+
                 pending.push_back(task);
                 storage.put("pending", pending).await?;
-                
+
                 Response::ok("enqueued")
             }
             (Method::Post, "/claim") => {
@@ -216,5 +285,84 @@ impl DurableObject for TaskLeaseManager {
         }
 
         Response::ok("alarm processed")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── enqueue_decision (backpressure rule) ────────────────────
+
+    #[test]
+    fn enqueue_decision_accepts_when_below_capacity() {
+        assert_eq!(enqueue_decision(0, 10), EnqueueDecision::Accept);
+        assert_eq!(enqueue_decision(5, 10), EnqueueDecision::Accept);
+        assert_eq!(enqueue_decision(9, 10), EnqueueDecision::Accept);
+    }
+
+    #[test]
+    fn enqueue_decision_rejects_at_capacity() {
+        // The handler increments the rejection counter and returns 429
+        // whenever this returns `Reject`, so the boundary behavior is part
+        // of the public contract.
+        assert_eq!(enqueue_decision(10, 10), EnqueueDecision::Reject);
+        assert_eq!(enqueue_decision(11, 10), EnqueueDecision::Reject);
+        assert_eq!(enqueue_decision(usize::MAX, 10), EnqueueDecision::Reject);
+    }
+
+    #[test]
+    fn enqueue_decision_uses_configured_max_pending_tasks() {
+        // Capacity boundary using the live constant: simulating a queue at
+        // MAX_PENDING_TASKS - 1 still accepts, MAX_PENDING_TASKS rejects.
+        assert_eq!(
+            enqueue_decision(MAX_PENDING_TASKS - 1, MAX_PENDING_TASKS),
+            EnqueueDecision::Accept,
+        );
+        assert_eq!(
+            enqueue_decision(MAX_PENDING_TASKS, MAX_PENDING_TASKS),
+            EnqueueDecision::Reject,
+        );
+    }
+
+    /// Simulates the rejection-counter bookkeeping the `/enqueue` handler
+    /// performs on a rejected enqueue: read prior total, increment, persist.
+    fn simulate_rejection_counter(prev: u64) -> u64 {
+        prev.saturating_add(1)
+    }
+
+    #[test]
+    fn rejection_counter_increments_per_rejected_enqueue() {
+        let mut total: u64 = 0;
+        for expected in 1..=5u64 {
+            // Each call to enqueue at capacity triggers exactly one
+            // increment, matching the handler's behavior.
+            assert_eq!(
+                enqueue_decision(MAX_PENDING_TASKS, MAX_PENDING_TASKS),
+                EnqueueDecision::Reject,
+            );
+            total = simulate_rejection_counter(total);
+            assert_eq!(total, expected);
+        }
+    }
+
+    #[test]
+    fn rejection_counter_saturates_instead_of_wrapping() {
+        // Defensive: the handler uses `saturating_add` so a long-lived DO
+        // can't underflow the metric back to zero.
+        assert_eq!(simulate_rejection_counter(u64::MAX), u64::MAX);
+    }
+
+    #[test]
+    fn max_pending_tasks_constant_is_documented_value() {
+        // Tripwire: changing the cap is a deliberate ops decision; the test
+        // forces the changer to update the doc comment and this assertion
+        // together.
+        assert_eq!(MAX_PENDING_TASKS, 10_000);
+    }
+
+    #[test]
+    fn retry_after_is_documented_value() {
+        assert_eq!(ENQUEUE_RETRY_AFTER_SECS, 30);
     }
 }


### PR DESCRIPTION
Draft — opened for review before marking ready.

## Why

Addresses two confirmed DoS surfaces flagged in the PR #132 crr:

1. **`src/lib.rs:566` (CRITICAL ops)** — `GET /v1/policies/rules` and `GET /v1/agents` returned every row for the tenant in one query. A tenant with thousands of rules or agents could exhaust worker memory and produce multi-second responses.
2. **`src/task_do.rs:34` (HIGH ops)** — `pending_tasks: VecDeque<AgentTask>` had no max. A burst of `/enqueue` calls against a slow consumer could grow DO storage without bound.

## What changed

### `src/pagination.rs`
- New `PolicyRulesCursor` carrying `(priority, created_at, id)` — three-field cursor so resuming is deterministic when many rules share `priority` and `created_at` (common when seeded in batches).
- New `AgentsCursor` carrying `(name, id)`.
- Both follow the existing `RunsCursor` shape (hex-encoded JSON, single-letter serde keys to keep the cursor short, `encode`/`decode` with the same error semantics).

### `src/db.rs`
- `list_policy_rules(d1, tenant_id, limit, cursor)` → `Result<(Vec<PolicyRuleRow>, Option<PolicyRulesCursor>)>`. Orders by `(priority DESC, created_at ASC, id ASC)`. Strict-after predicate is expressed as three OR-ed clauses because SQLite/D1 can't index `(a, b, c) > (?, ?, ?)` as a single sargable expression (same constraint that drove `list_runs`).
- `list_agents(d1, tenant_id, limit, cursor)` → `Result<(Vec<Agent>, Option<AgentsCursor>)>`. Orders by `(name ASC, id ASC)`, two-clause OR predicate.
- Both fetch `limit + 1` rows and trim the overflow probe to detect the next page without a second query, matching `list_runs`.
- Two pure helpers — `compute_policy_rules_next_cursor` and `compute_agents_next_cursor` — extracted so the truncation/cursor-build logic is unit-testable without D1.

### `src/lib.rs`
- `GET /v1/policies/rules` and `GET /v1/agents` parse `?limit=` (via `pagination::clamp_limit`, default 50, cap 200) and `?cursor=`, return `{ "rules"|"agents": [...], "next_cursor": "..." }`, and surface `INVALID_CURSOR` 400 / `CURSOR_ENCODE_FAILED` 500 via the existing `errors::error_response` envelope. Mirrors the `/v1/runs` handler verbatim.

### `src/task_do.rs`
- New `MAX_PENDING_TASKS = 10_000` constant. Documented choice: with ~2 KB per serialized `AgentTask`, 10k pending corresponds to ~20 MB DO storage — well under the per-DO limit but enough to absorb a normal burst.
- New `ENQUEUE_RETRY_AFTER_SECS = 30` and `PENDING_REJECTED_TOTAL_KEY` constants.
- New pure helper `enqueue_decision(current_len, max) -> EnqueueDecision` so the backpressure rule is unit-testable without the wasm runtime.
- `/enqueue` now checks `enqueue_decision(pending.len(), MAX_PENDING_TASKS)` *before* pushing. At capacity it:
  - Reads `pending_rejected_total` from DO storage, increments via `saturating_add(1)`, and persists.
  - Returns `429` with `Retry-After: 30` and `{ "error": { "code": "QUEUE_FULL", "message": "...", "details": {...} } }`.

## Tests added (+19, total 282 → 301)

Cursor types (`pagination::tests`):
- `policy_rules_cursor_roundtrips_through_hex`
- `policy_rules_cursor_decode_returns_none_for_absent_or_empty`
- `policy_rules_cursor_decode_errors_on_garbage`
- `agents_cursor_roundtrips_through_hex`
- `agents_cursor_decode_returns_none_for_absent_or_empty`
- `agents_cursor_decode_errors_on_garbage`

Pagination helpers (`db::tests`):
- `list_agents_helper_returns_no_cursor_when_results_under_limit`
- `list_agents_helper_returns_no_cursor_when_results_exactly_at_limit`
- `list_agents_helper_trims_overflow_and_returns_cursor`
- `list_policy_rules_helper_returns_no_cursor_when_results_under_limit`
- `list_policy_rules_helper_trims_overflow_and_returns_cursor`
- `list_policy_rules_helper_preserves_order_after_truncation`

Backpressure rule (`task_do::tests`):
- `enqueue_decision_accepts_when_below_capacity`
- `enqueue_decision_rejects_at_capacity`
- `enqueue_decision_uses_configured_max_pending_tasks`
- `rejection_counter_increments_per_rejected_enqueue`
- `rejection_counter_saturates_instead_of_wrapping`
- `max_pending_tasks_constant_is_documented_value`
- `retry_after_is_documented_value`

## Verification

```
$ RUSTFLAGS="-D warnings" cargo check --target wasm32-unknown-unknown -p data-fabric-worker
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.83s

$ RUSTFLAGS="-D warnings --cfg=coverage" cargo check --tests -p data-fabric-worker
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.95s

$ cargo clippy --target wasm32-unknown-unknown -p data-fabric-worker -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.61s

$ cargo test -p data-fabric-worker
    test result: ok. 301 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Out of scope

- `src/play_do.rs` and checkpoint code — owned by PR C.
- Tenant scoping concerns flagged elsewhere in the crr — owned by PR #136.
- `dfctl` updates / CI gate — owned by PR #135 (#134 owns the migration gate).
- `/metrics` endpoint surfacing the new `pending_rejected_total` counter — intentional follow-up. The counter is persisted now so the endpoint can be added without a schema change. Counter is per-DO instance (per-tenant queue), matching how the rest of the DO storage is scoped.

## Caveats

- The `/enqueue` handler body itself is not unit-tested directly — there is no DurableObject test harness in this crate today, consistent with `play_do.rs` and `thread_do.rs`. The backpressure decision and counter bookkeeping are extracted into pure helpers (`enqueue_decision`, `saturating_add`) and tested in isolation; the handler delegates to them verbatim.
- A pre-existing `cargo fmt` diff exists across many untouched files (`data-fabric-client`, `dfctl`, `thread_do.rs`, `play_do.rs`, etc.). Not fixed here to keep the PR scoped.