### PR TITLE
fix(do): check enqueue status, guard completed-race, decode task_id (crr2 of #143)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "js-sys",
+ "percent-encoding",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4"
 js-sys = "0.3"
 serde-wasm-bindgen = "0.6"
+percent-encoding = "2.3"
 
 [profile.release]
 lto = true

--- a/src/play_do.rs
+++ b/src/play_do.rs
@@ -196,16 +196,47 @@ impl PlayManager {
             // the error; the next materialize call will retry this and
             // remaining tasks because `derive_to_launch` still includes
             // anything not yet in `active_tasks`/`completed_tasks`.
-            if let Err(e) = task_stub.fetch_with_request(do_req).await {
+            let mut resp = match task_stub.fetch_with_request(do_req).await {
+                Ok(r) => r,
+                Err(e) => {
+                    worker::console_log!(
+                        "play_do: enqueue RPC failed for task {} of run {}: {}; \
+                         leaving active_tasks unchanged so a future materialize \
+                         call will retry",
+                        task_def.id,
+                        state.run_id,
+                        e,
+                    );
+                    return Err(e);
+                }
+            };
+
+            // crr2 CRITICAL finding (play_do.rs:199): `fetch_with_request`
+            // returns `Ok(_)` for ANY HTTP status, including 4xx / 5xx.
+            // Without this check, a transient TLM outage (500), a malformed
+            // payload (400), or quota exhaustion (429) was previously
+            // followed by marking the task active even though TLM never
+            // accepted it — regressing to the original stuck-active bug
+            // that motivated the per-task atomicity refactor. We now treat
+            // any non-2xx status as a failure: bail with an error so the
+            // caller can retry / surface the failure, and leave the task
+            // un-marked so the next materialize call re-derives it.
+            let status = resp.status_code();
+            if !is_enqueue_success(status) {
+                let body = resp.text().await.unwrap_or_default();
                 worker::console_log!(
-                    "play_do: enqueue RPC failed for task {} of run {}: {}; \
+                    "play_do: enqueue for task {} of run {} returned HTTP {}: {}; \
                      leaving active_tasks unchanged so a future materialize \
                      call will retry",
                     task_def.id,
                     state.run_id,
-                    e,
+                    status,
+                    body,
                 );
-                return Err(e);
+                return Err(Error::RustError(format!(
+                    "TLM enqueue for task {} returned {}: {}",
+                    task_def.id, status, body
+                )));
             }
 
             // RPC succeeded — now mark active and persist. We re-read
@@ -218,9 +249,24 @@ impl PlayManager {
                 .get("state")
                 .await?
                 .ok_or_else(|| Error::RustError("state not found".into()))?;
-            latest.active_tasks.insert(task_def.id.clone());
-            latest.state_version = latest.state_version.wrapping_add(1);
-            storage.put("state", &latest).await?;
+
+            // crr2 HIGH finding (play_do.rs:221): a concurrent
+            // `/task-completed` handler may have completed THIS task
+            // between our outbound RPC and the re-read above (e.g. a
+            // very fast agent that claimed, ran, and reported back while
+            // our input gate was still yielded). The re-read picks up
+            // that completion (task is now in `completed_tasks`), but
+            // an unconditional `active_tasks.insert` here resurrects it
+            // — the play would then have the same id in BOTH sets, and
+            // `derive_to_launch` would silently skip it forever, but a
+            // human reading state would see a contradictory record.
+            // Guard against this by only marking active when the task
+            // is not already completed. (No-op in the common case.)
+            if !latest.completed_tasks.contains(&task_def.id) {
+                latest.active_tasks.insert(task_def.id.clone());
+                latest.state_version = latest.state_version.wrapping_add(1);
+                storage.put("state", &latest).await?;
+            }
             state = latest;
         }
 
@@ -261,6 +307,64 @@ where
         }
     }
     (state, None)
+}
+
+/// Test-only enum modelling the outcome of a single per-task `/enqueue`
+/// RPC. Mirrors the production code's three failure shapes:
+///
+/// - `TransportErr`: the `fetch_with_request` future itself returned
+///   `Err(_)` (network blip, malformed DO binding, etc.).
+/// - `HttpStatus(non-2xx)`: `Ok(resp)` was returned but the body status
+///   code is not in 2xx. crr2 CRITICAL finding (play_do.rs:199): before
+///   the fix, the production loop treated this case as success.
+/// - `HttpStatus(2xx)`: success.
+#[cfg(test)]
+#[derive(Clone, Debug)]
+enum EnqueueOutcome {
+    HttpStatus(u16),
+    TransportErr,
+}
+
+/// Test-only simulator that mirrors the post-fix production loop more
+/// faithfully than `simulate_per_task_materialize`: it propagates the
+/// HTTP-status check via `is_enqueue_success`, so non-2xx responses
+/// also count as failure (with the task left un-marked). Use this for
+/// the crr2 CRITICAL regression tests; the older `_active_on_rpc_*`
+/// tests keep using `simulate_per_task_materialize` to pin the
+/// previous invariant.
+#[cfg(test)]
+fn simulate_per_task_materialize_with_status<F>(
+    initial: PlayState,
+    to_launch: &[PlayTaskDefinition],
+    mut rpc: F,
+) -> (PlayState, Option<usize>)
+where
+    F: FnMut(&PlayTaskDefinition) -> EnqueueOutcome,
+{
+    let mut state = initial;
+    for (idx, task_def) in to_launch.iter().enumerate() {
+        match rpc(task_def) {
+            EnqueueOutcome::HttpStatus(s) if is_enqueue_success(s) => {
+                state.active_tasks.insert(task_def.id.clone());
+                state.state_version = state.state_version.wrapping_add(1);
+            }
+            _ => return (state, Some(idx)),
+        }
+    }
+    (state, None)
+}
+
+/// Pure helper: is the HTTP status returned by TaskLeaseManager's
+/// `/enqueue` route an accept? We treat the 2xx range as success and
+/// everything else as a failure that bubbles up so the caller can retry.
+///
+/// Extracted as a free function so the per-task atomicity tests can
+/// directly model the production status-code branching without spinning
+/// up a Workers runtime (see `simulate_per_task_materialize`'s
+/// `EnqueueOutcome` enum). Mirror of the check in
+/// `materialize_eligible_tasks` — keep these two in sync.
+pub(crate) fn is_enqueue_success(status: u16) -> bool {
+    (200..300).contains(&status)
 }
 
 /// Pure derivation of eligible-to-launch tasks from a PlayState snapshot.
@@ -480,6 +584,160 @@ mod tests {
             "no task marked active when first RPC fails — \
              pre-fix would have stranded all three"
         );
+    }
+
+    // ── crr2 CRITICAL finding: play_do.rs:199 — status check on enqueue ─
+    //
+    // Before the crr2 fix, the loop did:
+    //   let _resp = task_stub.fetch_with_request(do_req).await?;
+    //   // ... immediately marks task as active in state
+    // `fetch_with_request` returns Ok(_) for ANY HTTP status, so when
+    // TLM returned 500 (transient outage, bad payload, quota), the task
+    // got marked active even though TLM did NOT accept it. The next
+    // materialize call's `derive_to_launch` would skip the task (it's
+    // in active_tasks), and TLM never lease-expires what it never
+    // received — regressing to the original stuck-active bug.
+
+    #[test]
+    fn is_enqueue_success_accepts_2xx() {
+        assert!(is_enqueue_success(200));
+        assert!(is_enqueue_success(201));
+        assert!(is_enqueue_success(204));
+        assert!(is_enqueue_success(299));
+    }
+
+    #[test]
+    fn is_enqueue_success_rejects_non_2xx() {
+        // The whole point of the crr2 CRITICAL fix: every non-2xx
+        // status must NOT be treated as a successful enqueue.
+        assert!(!is_enqueue_success(199));
+        assert!(!is_enqueue_success(300));
+        assert!(!is_enqueue_success(400));
+        assert!(!is_enqueue_success(404));
+        assert!(!is_enqueue_success(429));
+        assert!(!is_enqueue_success(500));
+        assert!(!is_enqueue_success(503));
+    }
+
+    #[test]
+    fn per_task_materialize_does_not_mark_active_on_5xx() {
+        // crr2 CRITICAL regression test. Before the fix, a 500 from TLM
+        // landed the task in `active_tasks` because the loop only
+        // matched on `Err(_)`. After the fix, a 5xx makes the loop
+        // bail and the failed task stays un-marked so a future
+        // materialize re-derives it.
+        let state = make_state(vec![task("a", &[]), task("b", &[]), task("c", &[])]);
+        let to_launch = derive_to_launch(&state);
+        let (final_state, err_idx) =
+            simulate_per_task_materialize_with_status(state, &to_launch, |t| {
+                if t.id == "b" {
+                    EnqueueOutcome::HttpStatus(500)
+                } else {
+                    EnqueueOutcome::HttpStatus(200)
+                }
+            });
+        assert_eq!(err_idx, Some(1), "loop aborts at 5xx task");
+        let active: HashSet<_> = final_state.active_tasks.iter().cloned().collect();
+        assert_eq!(
+            active,
+            HashSet::from(["a".to_string()]),
+            "only the 2xx-ack'd task is marked active; 5xx must NOT mark active",
+        );
+        assert!(
+            !final_state.active_tasks.contains("b"),
+            "the 5xx task must remain un-marked so a future materialize retries it",
+        );
+        assert!(!final_state.active_tasks.contains("c"));
+    }
+
+    #[test]
+    fn per_task_materialize_does_not_mark_active_on_4xx() {
+        // Same shape as the 5xx test but for a 4xx (e.g. 400 malformed
+        // payload, 429 quota). All non-2xx statuses must be treated as
+        // a non-ack to avoid the stuck-active regression.
+        let state = make_state(vec![task("a", &[]), task("b", &[])]);
+        let to_launch = derive_to_launch(&state);
+        let (final_state, err_idx) =
+            simulate_per_task_materialize_with_status(state, &to_launch, |t| {
+                if t.id == "a" {
+                    EnqueueOutcome::HttpStatus(429)
+                } else {
+                    EnqueueOutcome::HttpStatus(200)
+                }
+            });
+        assert_eq!(err_idx, Some(0), "loop aborts at the 429 first task");
+        assert!(
+            final_state.active_tasks.is_empty(),
+            "429 on the first task leaves nothing active",
+        );
+    }
+
+    #[test]
+    fn per_task_materialize_treats_transport_err_as_failure() {
+        // Transport-level failure (the old `.await?` path) must still
+        // bail without marking the task active. This guards against
+        // a regression where someone tightens the status check but
+        // accidentally loosens the transport-error handling.
+        let state = make_state(vec![task("a", &[]), task("b", &[])]);
+        let to_launch = derive_to_launch(&state);
+        let (final_state, err_idx) =
+            simulate_per_task_materialize_with_status(state, &to_launch, |_| {
+                EnqueueOutcome::TransportErr
+            });
+        assert_eq!(err_idx, Some(0));
+        assert!(final_state.active_tasks.is_empty());
+    }
+
+    // ── crr2 HIGH finding: play_do.rs:221 — race with /task-completed ─
+    //
+    // After the per-task enqueue succeeds the loop re-reads state from
+    // storage to fold in concurrent `/task-completed` mutations that
+    // landed while our input gate was yielded on the outbound RPC's
+    // await. Before the crr2 fix the loop unconditionally did
+    // `latest.active_tasks.insert(task_def.id.clone())` — which, if a
+    // concurrent handler had already moved the task into
+    // `completed_tasks` (e.g. a very fast agent picked it up and
+    // reported back), would resurrect the task by putting it in BOTH
+    // sets. derive_to_launch then silently skips it forever (it's in
+    // active_tasks), but the durable record is internally
+    // contradictory. The post-fix code only inserts when the task is
+    // NOT already in completed_tasks.
+
+    /// Test-only mirror of the post-fix insert decision: only mark
+    /// active when the task is not already in completed_tasks. If this
+    /// and the production loop diverge in future edits, the test
+    /// becomes a tripwire.
+    fn should_mark_active(latest: &PlayState, task_id: &str) -> bool {
+        !latest.completed_tasks.contains(task_id)
+    }
+
+    #[test]
+    fn race_with_task_completed_does_not_resurrect_completed_task() {
+        // Simulate the race: we issued the enqueue for "a"; while we
+        // were awaiting, /task-completed for "a" ran (e.g. via a TLM
+        // notify-retry that beat our re-read by inches) and moved "a"
+        // into completed_tasks. The re-read picks that up. Without the
+        // fix we would re-insert into active_tasks; with the fix we
+        // leave it alone.
+        let mut latest = make_state(vec![task("a", &[]), task("b", &[])]);
+        latest.completed_tasks.insert("a".to_string());
+
+        assert!(
+            !should_mark_active(&latest, "a"),
+            "completed task must NOT be re-marked active by the post-RPC re-read",
+        );
+        assert!(
+            should_mark_active(&latest, "b"),
+            "uncompleted task is still safe to mark active",
+        );
+    }
+
+    #[test]
+    fn race_no_completion_marks_active_as_usual() {
+        // Sanity: the common case (no concurrent completion) still
+        // marks the task active.
+        let latest = make_state(vec![task("a", &[])]);
+        assert!(should_mark_active(&latest, "a"));
     }
 
     #[test]

--- a/src/task_do.rs
+++ b/src/task_do.rs
@@ -1,4 +1,5 @@
 use crate::models::{AgentTask, TaskFailRequest};
+use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use worker::*;
@@ -84,8 +85,20 @@ impl DurableObject for TaskLeaseManager {
         // #142's tests. We now match by prefix and pull task_id out of
         // the trailing segment, mirroring the parsing the original
         // handler attempted via `req.path().split('/').nth(2)`.
-        let complete_task_id = path.strip_prefix("/complete/").map(|s| s.to_string());
-        let fail_task_id = path.strip_prefix("/fail/").map(|s| s.to_string());
+        //
+        // crr2 MEDIUM finding (task_do.rs:87): the strip_prefix path
+        // suffix is the raw URL path, which is percent-encoded by the
+        // caller (data-fabric-client PR #140's URL encoding fix, plus
+        // anything routed by Workers' router). If we used the encoded
+        // form as the hashmap key the lookup would silently miss vs.
+        // the `/enqueue` path which deserializes from JSON (no
+        // encoding). Decode to the canonical form here.
+        let complete_task_id = path
+            .strip_prefix("/complete/")
+            .and_then(decode_task_id_segment);
+        let fail_task_id = path
+            .strip_prefix("/fail/")
+            .and_then(decode_task_id_segment);
 
         match (method, path.as_str()) {
             (Method::Post, "/enqueue") => {
@@ -571,6 +584,34 @@ pub(crate) fn split_due_pending(
     (due, deferred)
 }
 
+/// Pure helper: percent-decode a `/complete/<task_id>` or
+/// `/fail/<task_id>` path tail into the canonical task id. Returns
+/// `None` for an empty segment, an invalid UTF-8 percent-encoding, or
+/// a decoded value that is empty after decoding.
+///
+/// crr2 MEDIUM finding (task_do.rs:87): the previous strip_prefix path
+/// kept the percent-encoded form (e.g. `task%2Dabc`) and used it as a
+/// hashmap key. The corresponding `/enqueue` path deserialises the
+/// task id from JSON, so the key in `active` was already in canonical
+/// form — meaning a percent-encoded `/complete/...` lookup silently
+/// missed and returned `404 task not found`. Decoding here makes the
+/// keying consistent regardless of caller encoding.
+///
+/// Extracted as a `pub(crate)` free function so it can be unit-tested
+/// without spinning up a Workers runtime.
+pub(crate) fn decode_task_id_segment(raw: &str) -> Option<String> {
+    if raw.is_empty() {
+        return None;
+    }
+    let decoded = percent_decode_str(raw).decode_utf8().ok()?;
+    let decoded = decoded.into_owned();
+    if decoded.is_empty() {
+        None
+    } else {
+        Some(decoded)
+    }
+}
+
 /// Pure helper: extract `task_id` from a DO request path of the form
 /// `/<route>/<task_id>` for the parameterised routes `/complete` and
 /// `/fail`. Returns `Some(task_id)` when the path matches the given
@@ -586,11 +627,9 @@ pub(crate) fn split_due_pending(
 pub(crate) fn parse_task_id_from_path(path: &str, route: &str) -> Option<String> {
     let prefix = format!("/{}/", route.trim_matches('/'));
     let tail = path.strip_prefix(&prefix)?;
-    if tail.is_empty() {
-        None
-    } else {
-        Some(tail.to_string())
-    }
+    // Mirror the production decode step (crr2 MEDIUM finding) so this
+    // helper stays a faithful model of the live `fetch` routing.
+    decode_task_id_segment(tail)
 }
 
 /// Pure helper: upsert a PendingNotify into the in-memory list, keyed
@@ -788,6 +827,93 @@ mod tests {
             .expect("lib.rs caller URL must yield a non-empty task id");
         assert!(!task_id.is_empty());
         assert_eq!(task_id, "run-42-summarise");
+    }
+
+    // ── crr2 MEDIUM finding: task_do.rs:87 — URL-decoded task_id ──────
+    //
+    // The strip_prefix("/complete/") path parsing kept the raw
+    // percent-encoded suffix. data-fabric-client (PR #140) URL-encodes
+    // path segments per RFC 3986, so a task id like
+    // `task-with space` arrives as `task-with%20space`. The hashmap
+    // key in `active` is the JSON-deserialised (canonical) form from
+    // `/enqueue`, so the encoded lookup would miss and return
+    // `404 task not found`. The fix decodes here.
+
+    #[test]
+    fn decode_task_id_segment_passes_through_unencoded_id() {
+        assert_eq!(
+            decode_task_id_segment("task-abc-123"),
+            Some("task-abc-123".to_string()),
+        );
+    }
+
+    #[test]
+    fn decode_task_id_segment_percent_decodes_spaces() {
+        // The bug shape: client encoded ' ' as '%20'; the DO key was
+        // stored as the canonical form on /enqueue. Pre-fix, the
+        // active.remove(&"task%20abc") missed; post-fix it hits.
+        assert_eq!(
+            decode_task_id_segment("task%20abc"),
+            Some("task abc".to_string()),
+        );
+    }
+
+    #[test]
+    fn decode_task_id_segment_handles_reserved_chars() {
+        // Reserved chars per RFC 3986 — client-side URL encoders
+        // typically escape `/`, `?`, `#`, `&`, `=` etc. when present
+        // inside a path segment. We must round-trip them back to the
+        // canonical form so the active-task lookup hits.
+        assert_eq!(
+            decode_task_id_segment("run%2F42%23summarise"),
+            Some("run/42#summarise".to_string()),
+        );
+    }
+
+    #[test]
+    fn decode_task_id_segment_returns_none_for_empty() {
+        // Empty segment is treated as a parse failure (mirrors the
+        // pre-existing `parse_task_id_from_path` contract that returns
+        // None for `/complete/`).
+        assert_eq!(decode_task_id_segment(""), None);
+    }
+
+    #[test]
+    fn decode_task_id_segment_returns_none_for_invalid_utf8_percent_encoding() {
+        // `%FF%FE` is not valid UTF-8 — should bail rather than
+        // produce a corrupted key that misses the active-task map.
+        assert_eq!(decode_task_id_segment("%FF%FE"), None);
+    }
+
+    #[test]
+    fn parse_task_id_decodes_percent_encoded_segment() {
+        // End-to-end on the parsing helper used by the routing
+        // contract test. Pre-crr2 this returned Some("task%20abc")
+        // verbatim and the active.remove lookup missed.
+        assert_eq!(
+            parse_task_id_from_path("/complete/task%20abc", "complete"),
+            Some("task abc".to_string()),
+        );
+        assert_eq!(
+            parse_task_id_from_path("/fail/task%2Fabc", "fail"),
+            Some("task/abc".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_task_id_round_trips_url_encoded_caller_url() {
+        // Regression: data-fabric-client PR #140 url-encodes path
+        // segments, so the lib.rs caller may forward an encoded
+        // task_id into the DO URL. The decoded form must match the
+        // canonical key stored on /enqueue.
+        let canonical = "run-42 summarise/v2";
+        let encoded =
+            percent_encoding::utf8_percent_encode(canonical, percent_encoding::NON_ALPHANUMERIC)
+                .to_string();
+        let path = format!("/complete/{}", encoded);
+        let task_id = parse_task_id_from_path(&path, "complete")
+            .expect("encoded caller URL must yield a decoded task id");
+        assert_eq!(task_id, canonical);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Follow-up to merged PR #143 addressing three crr2 review findings that surfaced after merge. The fixes are scoped strictly to the findings — no behavior change otherwise.

- **CRITICAL — `src/play_do.rs:199`**: `task_stub.fetch_with_request(...).await` returns `Ok(_)` for ANY HTTP status. Before this fix, a 4xx/5xx from TaskLeaseManager (transient outage, malformed payload, quota) was followed by marking the task active — re-introducing the original stuck-active bug the per-task atomicity refactor was meant to eliminate (`derive_to_launch` skips active tasks; TLM never lease-expires what it never received). Now checks `resp.status_code()` via new `is_enqueue_success` helper; non-2xx bails with `Error::RustError(...)` carrying status + body so the caller can retry / surface.
- **HIGH — `src/play_do.rs:221`**: post-RPC re-read of state unconditionally re-inserted into `active_tasks` even when a concurrent `/task-completed` had already moved the task into `completed_tasks` (e.g. a fast agent that claimed + completed while our input gate was yielded on the outbound RPC's await). That would put the task id in BOTH sets and produce internally-contradictory state. Now guards the insert behind `!latest.completed_tasks.contains(...)`.
- **MEDIUM — `src/task_do.rs:87`**: `strip_prefix("/complete/")` kept the percent-encoded suffix and used it as the active-tasks hashmap key. data-fabric-client PR #140 url-encodes path segments per RFC 3986, but `/enqueue` stores tasks under the canonical JSON-deserialised key, so a percent-encoded `/complete/...` lookup silently missed and returned 404. Added `percent-encoding = "2.3"` direct dep (already transitive) + new `decode_task_id_segment` helper that percent-decodes the suffix and rejects empty / invalid-UTF-8.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo check --target wasm32-unknown-unknown -p data-fabric-worker` — green
- [x] `RUSTFLAGS="-D warnings --cfg=coverage" cargo check --tests -p data-fabric-worker` — green
- [x] `cargo test -p data-fabric-worker` — 324 passed, 0 failed (was 310 — adds 14 regression tests)
- [x] `RUSTFLAGS="-D warnings" cargo check -p data-fabric-client` — green
- [x] `cargo test -p data-fabric-client` — 1 passed, 0 failed

New regression tests pin the contracts:
- `is_enqueue_success_accepts_2xx` / `_rejects_non_2xx`
- `per_task_materialize_does_not_mark_active_on_5xx` / `_on_4xx`
- `per_task_materialize_treats_transport_err_as_failure`
- `race_with_task_completed_does_not_resurrect_completed_task`
- `race_no_completion_marks_active_as_usual`
- `decode_task_id_segment_*` (passthrough, spaces, reserved chars, empty, invalid UTF-8)
- `parse_task_id_decodes_percent_encoded_segment`
- `parse_task_id_round_trips_url_encoded_caller_url`

Existing `parse_task_id_from_path` test helper updated to call `decode_task_id_segment` so it faithfully mirrors the production routing decode step.

Refs: #143 (merged), #140 (URL encoding).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>