### PR TITLE
fix(security): percent-encode user inputs in claim/heartbeat URLs (follow-up to #140)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
 name = "data-fabric-client"
 version = "0.1.1"
 dependencies = [
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",
@@ -281,6 +282,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "url",
  "wasm-bindgen",
  "worker",
  "worker-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4"
 js-sys = "0.3"
 serde-wasm-bindgen = "0.6"
+url = "2"
 
 [profile.release]
 lto = true

--- a/data-fabric-client/Cargo.toml
+++ b/data-fabric-client/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
+percent-encoding = "2"

--- a/data-fabric-client/src/lib.rs
+++ b/data-fabric-client/src/lib.rs
@@ -1,8 +1,30 @@
 pub mod types;
 
 use types::*;
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use reqwest::{Client as HttpClient, Method, RequestBuilder, StatusCode};
 use serde::{de::DeserializeOwned, Serialize};
+
+/// Reserved character set for a single URI path segment per RFC 3986. Anything
+/// outside `pchar` (which excludes `/`, `?`, `#`, etc.) must be percent-encoded
+/// or a caller could smuggle additional path segments or query strings into
+/// the URL via a crafted ID.
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}')
+    .add(b'/')
+    .add(b'%');
+
+fn encode_path_segment(s: &str) -> String {
+    utf8_percent_encode(s, PATH_SEGMENT_ENCODE_SET).to_string()
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -211,18 +233,24 @@ impl Client {
     /// * `agent_id` is a required query parameter.
     /// * `cap` is an optional comma-separated query parameter.
     /// * No request body — inputs come exclusively from the query string.
+    ///
+    /// Query parameters are appended via `reqwest::RequestBuilder::query`, which
+    /// percent-encodes each value. Interpolating user-controlled inputs into the
+    /// URL string with `format!` would let a caller smuggle extra parameters
+    /// (e.g. `agent_id="agent-1&cap=evil"` would inject a second `cap`).
     pub fn build_claim_next_task_request(
         &self,
         agent_id: &str,
         capabilities: &[String],
     ) -> Result<reqwest::Request> {
-        let path = if capabilities.is_empty() {
-            format!("/mcp/task/next?agent_id={}", agent_id)
-        } else {
+        let mut builder = self
+            .prepare_request(Method::POST, "/mcp/task/next")
+            .query(&[("agent_id", agent_id)]);
+        if !capabilities.is_empty() {
             let caps = capabilities.join(",");
-            format!("/mcp/task/next?agent_id={}&cap={}", agent_id, caps)
-        };
-        self.prepare_request(Method::POST, &path).build().map_err(Error::from)
+            builder = builder.query(&[("cap", caps.as_str())]);
+        }
+        builder.build().map_err(Error::from)
     }
 
     pub async fn claim_next_task(&self, agent_id: &str, capabilities: &[String]) -> Result<Option<AgentTask>> {
@@ -236,8 +264,28 @@ impl Client {
     }
 
     pub async fn heartbeat_task(&self, task_id: &str, agent_id: &str) -> Result<serde_json::Value> {
-        let path = format!("/mcp/task/{}/heartbeat?agent_id={}", task_id, agent_id);
-        self.send_request::<(), serde_json::Value>(Method::POST, &path, None).await
+        let req = self.build_heartbeat_task_request(task_id, agent_id)?;
+        let resp = self.http.execute(req).await?;
+        self.handle_response(resp).await
+    }
+
+    /// Build the HTTP request used by [`Client::heartbeat_task`].
+    ///
+    /// `task_id` is percent-encoded into the path segment and `agent_id` is
+    /// appended as a percent-encoded query parameter (`reqwest`'s `.query()`
+    /// builder handles encoding). Interpolating either value with `format!`
+    /// would let a caller inject extra path segments or query parameters via
+    /// a crafted ID like `task_id = "abc/extra?injected=1"`.
+    pub fn build_heartbeat_task_request(
+        &self,
+        task_id: &str,
+        agent_id: &str,
+    ) -> Result<reqwest::Request> {
+        let path = format!("/mcp/task/{}/heartbeat", encode_path_segment(task_id));
+        self.prepare_request(Method::POST, &path)
+            .query(&[("agent_id", agent_id)])
+            .build()
+            .map_err(Error::from)
     }
 
     pub async fn complete_task(&self, task_id: &str, req: &TaskCompleteRequest) -> Result<serde_json::Value> {
@@ -380,7 +428,10 @@ mod tests {
     }
 
     /// `agent_id` and `cap` belong on the query string (the new POST handler
-    /// reads them from `url.query_pairs()`), not in a JSON body.
+    /// reads them from `url.query_pairs()`), not in a JSON body. We assert
+    /// against the *decoded* query pairs because the URL builder may percent-
+    /// encode sub-delims like `,` — that's still a valid `cap=rust,wasm` from
+    /// the server's perspective (which decodes via `url.query_pairs()`).
     #[test]
     fn claim_next_task_puts_inputs_in_query_string_not_body() {
         let client = test_client();
@@ -389,9 +440,12 @@ mod tests {
             .expect("request must build");
         let url = req.url();
         assert_eq!(url.path(), "/mcp/task/next");
-        let query = url.query().expect("query string must be present");
-        assert!(query.contains("agent_id=agent-1"), "agent_id must be a query param, got: {query}");
-        assert!(query.contains("cap=rust,wasm"), "cap must be a comma-separated query param, got: {query}");
+        let pairs: std::collections::HashMap<String, String> = url
+            .query_pairs()
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        assert_eq!(pairs.get("agent_id").map(String::as_str), Some("agent-1"));
+        assert_eq!(pairs.get("cap").map(String::as_str), Some("rust,wasm"));
         assert!(req.body().is_none(), "POST body must be empty; the handler reads from query params");
     }
 
@@ -408,5 +462,92 @@ mod tests {
         let query = req.url().query().unwrap_or("");
         assert!(query.contains("agent_id=agent-1"));
         assert!(!query.contains("cap="), "cap must be omitted when no capabilities are supplied, got: {query}");
+    }
+
+    /// Regression test: `agent_id` and the `cap` values must be percent-encoded
+    /// so a malicious caller can't smuggle an extra query parameter through the
+    /// URL. Before the fix, `agent_id="user@host&cap=evil"` was interpolated
+    /// raw and injected a second `cap=evil` parameter that the server would
+    /// then merge with the legitimate `cap=rust`.
+    #[test]
+    fn claim_next_task_encodes_special_chars_in_agent_id() {
+        let client = test_client();
+        let req = client
+            .build_claim_next_task_request("user@host&cap=evil", &["rust".to_string()])
+            .expect("request must build");
+        let url = req.url();
+        let query = url.query().expect("query string must be present");
+
+        // The `&` and `=` in the supplied agent_id must be percent-encoded so
+        // they appear inside the single agent_id value, not as separators.
+        assert!(
+            !query.contains("agent_id=user@host&cap=evil"),
+            "agent_id must be percent-encoded; raw injection allowed extra cap, got: {query}"
+        );
+
+        // Exactly one `cap` parameter must be present (the legitimate one).
+        let cap_count = url
+            .query_pairs()
+            .filter(|(k, _)| k == "cap")
+            .count();
+        assert_eq!(cap_count, 1, "expected exactly one cap param, got {cap_count} in {query}");
+
+        // The agent_id pair must round-trip to the original (decoded) value.
+        let agent_id_value = url
+            .query_pairs()
+            .find(|(k, _)| k == "agent_id")
+            .map(|(_, v)| v.into_owned())
+            .expect("agent_id must be present");
+        assert_eq!(agent_id_value, "user@host&cap=evil");
+    }
+
+    /// Regression test: `task_id` is a path segment and `agent_id` is a query
+    /// parameter — both must be percent-encoded. Before the fix,
+    /// `task_id="abc/extra?injected=1"` was interpolated raw into the path and
+    /// turned a heartbeat into a request against `/mcp/task/abc/extra/heartbeat`
+    /// with a synthetic `injected=1` query parameter.
+    #[test]
+    fn heartbeat_task_encodes_special_chars_in_path_and_query() {
+        let client = test_client();
+        let req = client
+            .build_heartbeat_task_request("abc/extra?injected=1", "agent&id=evil")
+            .expect("request must build");
+        let url = req.url();
+        assert_eq!(req.method(), &Method::POST);
+
+        // The crafted `/` and `?` in task_id must be percent-encoded inside
+        // a single path segment, not interpreted as path/query separators.
+        let path = url.path();
+        assert!(
+            path.starts_with("/mcp/task/") && path.ends_with("/heartbeat"),
+            "path must wrap an encoded task_id segment, got: {path}"
+        );
+        assert!(
+            !path.contains("/extra/"),
+            "task_id slash must be encoded, got: {path}"
+        );
+        assert!(
+            !path.contains('?'),
+            "task_id question mark must be encoded, got: {path}"
+        );
+
+        // Exactly one `agent_id` query parameter; no injected ones.
+        let agent_count = url.query_pairs().filter(|(k, _)| k == "agent_id").count();
+        assert_eq!(agent_count, 1, "expected exactly one agent_id param");
+
+        // No injected `injected=1` parameter from the task_id.
+        assert!(
+            url.query_pairs().all(|(k, _)| k != "injected"),
+            "task_id must not be able to inject query params: {:?}",
+            url.query()
+        );
+
+        // agent_id round-trips with its `&` and `=` preserved as data.
+        let agent_id_value = url
+            .query_pairs()
+            .find(|(k, _)| k == "agent_id")
+            .map(|(_, v)| v.into_owned())
+            .expect("agent_id must be present");
+        assert_eq!(agent_id_value, "agent&id=evil");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,115 @@ fn request_path(req: &Request) -> Result<String> {
     Ok(req.url()?.path().to_string())
 }
 
+/// Build a URL targeting the internal `https://do/...` namespace used by
+/// Durable Object stubs, with each query parameter percent-encoded.
+///
+/// The previous implementation interpolated user-controlled values
+/// (`agent_id`, `task_id`, `cap`) into the URL with `format!`. A caller
+/// supplying e.g. `agent_id = "agent-1&caps=evil"` would inject a second
+/// `caps` parameter on its way through the DO boundary. Using
+/// `url::Url::query_pairs_mut` ensures each value is percent-encoded.
+fn build_do_url(path: &str, params: &[(&str, &str)]) -> Result<String> {
+    let mut url = url::Url::parse("https://do")
+        .map_err(|e| Error::RustError(format!("internal: bad DO base url: {}", e)))?;
+    // `path` is a developer-controlled literal (e.g. "/claim"), so we can set
+    // it directly. We only encode the dynamic params.
+    url.set_path(path);
+    {
+        let mut qp = url.query_pairs_mut();
+        for (k, v) in params {
+            qp.append_pair(k, v);
+        }
+    }
+    Ok(url.into())
+}
+
+#[cfg(test)]
+mod do_url_tests {
+    use super::build_do_url;
+
+    /// Regression test for the URL-injection findings in crr2:
+    /// values passed via `params` must be percent-encoded so a caller can't
+    /// smuggle additional query parameters across the DO boundary.
+    #[test]
+    fn build_do_url_encodes_injected_query_separators() {
+        let url = build_do_url(
+            "/claim",
+            &[
+                ("agent_id", "agent-1&caps=evil"),
+                ("caps", "rust"),
+            ],
+        )
+        .expect("url must build");
+
+        let parsed = url::Url::parse(&url).expect("url must parse");
+        assert_eq!(parsed.scheme(), "https");
+        assert_eq!(parsed.host_str(), Some("do"));
+        assert_eq!(parsed.path(), "/claim");
+
+        // Exactly one `caps` parameter — the legitimate one. If the injected
+        // `&caps=evil` had been interpolated raw, we'd see two.
+        let caps_count = parsed
+            .query_pairs()
+            .filter(|(k, _)| k == "caps")
+            .count();
+        assert_eq!(caps_count, 1, "expected one caps param, url was: {}", url);
+
+        // The agent_id round-trips with `&` and `=` preserved as data, not
+        // interpreted as separators.
+        let agent_id_value = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "agent_id")
+            .map(|(_, v)| v.into_owned())
+            .expect("agent_id must be present");
+        assert_eq!(agent_id_value, "agent-1&caps=evil");
+
+        // Sanity: the legitimate caps value is preserved.
+        let caps_value = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "caps")
+            .map(|(_, v)| v.into_owned())
+            .expect("caps must be present");
+        assert_eq!(caps_value, "rust");
+    }
+
+    #[test]
+    fn build_do_url_encodes_path_aware_chars_in_query() {
+        let url = build_do_url(
+            "/heartbeat",
+            &[
+                ("task_id", "abc/extra?injected=1"),
+                ("agent_id", "agent#1"),
+            ],
+        )
+        .expect("url must build");
+
+        let parsed = url::Url::parse(&url).expect("url must parse");
+        assert_eq!(parsed.path(), "/heartbeat");
+
+        // No injected `injected=1` from task_id.
+        assert!(
+            parsed.query_pairs().all(|(k, _)| k != "injected"),
+            "task_id must not smuggle additional params: {}",
+            url
+        );
+
+        let task_id = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "task_id")
+            .map(|(_, v)| v.into_owned())
+            .expect("task_id must be present");
+        assert_eq!(task_id, "abc/extra?injected=1");
+
+        let agent_id = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "agent_id")
+            .map(|(_, v)| v.into_owned())
+            .expect("agent_id must be present");
+        assert_eq!(agent_id, "agent#1");
+    }
+}
+
 /// Augment a claimed task with agent's memory context from MOM.
 ///
 /// Enables agents to reason with past experiences by injecting relevant memories
@@ -764,7 +873,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
             let namespace = ctx.env.durable_object("TASK_LEASE_MANAGER")?;
             let stub = namespace.id_from_name(&tenant_ctx.tenant_id)?.get_stub()?;
 
-            let do_url = format!("https://do/claim?agent_id={}&caps={}", agent_id, caps);
+            let do_url = build_do_url("/claim", &[("agent_id", &agent_id), ("caps", &caps)])?;
             let do_req = Request::new(&do_url, Method::Post)?;
             let mut do_resp = stub.fetch_with_request(do_req).await?;
 
@@ -843,7 +952,10 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
             let namespace = ctx.env.durable_object("TASK_LEASE_MANAGER")?;
             let stub = namespace.id_from_name(&tenant_ctx.tenant_id)?.get_stub()?;
             
-            let do_url = format!("https://do/heartbeat?task_id={}&agent_id={}", task_id, agent_id);
+            let do_url = build_do_url(
+                "/heartbeat",
+                &[("task_id", &task_id), ("agent_id", &agent_id)],
+            )?;
             let do_req = Request::new(&do_url, Method::Post)?;
             let do_resp = stub.fetch_with_request(do_req).await?;
 


### PR DESCRIPTION
## Why

PR #140 was merged before the crr2 pass caught **5 HIGH-severity URL-injection findings** across the client and worker. This is the follow-up that lands those fixes.

A malicious or unexpected \`agent_id\` like \`agent-1&cap=evil\` would inject extra query parameters into both the client→worker request AND the worker→DO RPC, hijacking capability filtering and access controls.

## What changed

All 5 sites now route user-controlled values through proper URL encoding instead of \`format!()\` interpolation:

### Client (\`data-fabric-client/src/lib.rs\`)
- \`claim_next_task\`: \`agent_id\` and \`cap\` (comma-joined) via \`reqwest::RequestBuilder::query\` — percent-encoded automatically.
- \`heartbeat_task\`: \`task_id\` percent-encoded as path segment via the \`percent-encoding\` crate; \`agent_id\` via \`.query()\`. Extracted helper \`build_heartbeat_task_request\` for unit-testability.

### Worker (\`src/lib.rs\`)
- \`POST /mcp/task/next\` and \`POST /mcp/task/:id/heartbeat\`: DO-bound URLs now built via new \`build_do_url\` helper using \`url::Url::query_pairs_mut\`.

## Tests added

- Client: \`claim_next_task_encodes_special_chars_in_agent_id\`, \`heartbeat_task_encodes_special_chars_in_path_and_query\`.
- Worker: \`do_url_tests::build_do_url_encodes_injected_query_separators\`, \`build_do_url_encodes_path_aware_chars_in_query\`.

## Verification

All clean with \`-D warnings\`:
- \`cargo check --target wasm32-unknown-unknown -p data-fabric-worker\`
- \`cargo check --tests -p data-fabric-worker\` (with \`--cfg=coverage\`)
- \`cargo test -p data-fabric-worker\` — 291 passed, 0 failed
- \`cargo check -p data-fabric-client\`
- \`cargo test -p data-fabric-client\` — 5 lib + 1 integration passed

## Notes

- One pre-existing client test (\`claim_next_task_puts_inputs_in_query_string_not_body\`) had to be rewritten to use decoded query pairs rather than raw substring matching, because \`reqwest::RequestBuilder::query\` percent-encodes \`,\` as a sub-delim (\`cap=rust%2Cwasm\` on the wire decodes to \`rust,wasm\` server-side via \`url.query_pairs()\`). Semantic contract preserved.
- Two crates promoted from transitive to direct deps: \`percent-encoding\` (client) and \`url\` (worker). Both were already in \`Cargo.lock\` via reqwest/worker respectively, so no new build cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)