### PR TITLE
feat(aivcs): register AIVCS event-taxonomy constants

### DIFF
--- a/src/models/aivcs_events.rs
+++ b/src/models/aivcs_events.rs
@@ -1,0 +1,242 @@
+//! Canonical AIVCS event_type constants. Use these instead of string literals.
+//!
+//! These constants declare the AIVCS event taxonomy from issue #148. They are
+//! informational: callers should reference them instead of inline string
+//! literals so we can audit which event types AIVCS expects. There is no
+//! runtime gate (whitelist) against this list yet — that is a separate
+//! decision tracked under issue #148.
+
+// AIVCS lifecycle events
+pub const AIVCS_REPOSITORY_SYNCED: &str = "aivcs.repository.synced";
+pub const AIVCS_BRANCH_CREATED: &str = "aivcs.branch.created";
+pub const AIVCS_COMMIT_INGESTED: &str = "aivcs.commit.ingested";
+pub const AIVCS_CHANGE_SET_PROPOSED: &str = "aivcs.change_set.proposed";
+pub const AIVCS_DIFF_ARTIFACT_STORED: &str = "aivcs.diff.artifact_stored";
+pub const AIVCS_REVIEW_OPENED: &str = "aivcs.review.opened";
+pub const AIVCS_REVIEW_THREAD_CREATED: &str = "aivcs.review_thread.created";
+
+// Agent events
+pub const AGENT_INTENT_RECORDED: &str = "agent.intent.recorded";
+pub const AGENT_PLAN_CREATED: &str = "agent.plan.created";
+pub const AGENT_TOOL_REQUESTED: &str = "agent.tool.requested";
+pub const AGENT_TOOL_COMPLETED: &str = "agent.tool.completed";
+pub const AGENT_CONFIDENCE_UPDATED: &str = "agent.confidence.updated";
+pub const AGENT_RISK_UPDATED: &str = "agent.risk.updated";
+
+// CI events
+pub const CI_CHECK_STARTED: &str = "ci.check.started";
+pub const CI_CHECK_COMPLETED: &str = "ci.check.completed";
+pub const CI_CHECK_FAILED: &str = "ci.check.failed";
+
+// Policy events
+pub const POLICY_CHECK_REQUESTED: &str = "policy.check.requested";
+pub const POLICY_DECISION_RECORDED: &str = "policy.decision.recorded";
+pub const POLICY_ESCALATION_CREATED: &str = "policy.escalation.created";
+
+// Human events
+pub const HUMAN_GUIDANCE_ADDED: &str = "human.guidance.added";
+pub const HUMAN_CONSTRAINT_ADDED: &str = "human.constraint.added";
+pub const HUMAN_REVIEW_COMMENT_ADDED: &str = "human.review.comment_added";
+pub const HUMAN_APPROVED: &str = "human.approved";
+pub const HUMAN_REQUESTED_CHANGES: &str = "human.requested_changes";
+pub const HUMAN_PAUSED_AGENT: &str = "human.paused_agent";
+pub const HUMAN_RESUMED_AGENT: &str = "human.resumed_agent";
+pub const HUMAN_MERGE_REQUESTED: &str = "human.merge_requested";
+
+// Merge / release events
+pub const AIVCS_MERGE_GUARDRAILS_STARTED: &str = "aivcs.merge.guardrails_started";
+pub const AIVCS_MERGE_BLOCKED: &str = "aivcs.merge.blocked";
+pub const AIVCS_MERGE_COMPLETED: &str = "aivcs.merge.completed";
+pub const AIVCS_RELEASE_CREATED: &str = "aivcs.release.created";
+
+/// All canonical AIVCS event_type constants, declared in stable order.
+///
+/// Iterate over this slice for documentation, snapshot tests, or to feed an
+/// allowlist later. Do NOT take a runtime dependency on the ordering for
+/// correctness — only for human-readable output / grep-ability.
+pub const ALL: &[&str] = &[
+    // AIVCS lifecycle
+    AIVCS_REPOSITORY_SYNCED,
+    AIVCS_BRANCH_CREATED,
+    AIVCS_COMMIT_INGESTED,
+    AIVCS_CHANGE_SET_PROPOSED,
+    AIVCS_DIFF_ARTIFACT_STORED,
+    AIVCS_REVIEW_OPENED,
+    AIVCS_REVIEW_THREAD_CREATED,
+    // Agent
+    AGENT_INTENT_RECORDED,
+    AGENT_PLAN_CREATED,
+    AGENT_TOOL_REQUESTED,
+    AGENT_TOOL_COMPLETED,
+    AGENT_CONFIDENCE_UPDATED,
+    AGENT_RISK_UPDATED,
+    // CI
+    CI_CHECK_STARTED,
+    CI_CHECK_COMPLETED,
+    CI_CHECK_FAILED,
+    // Policy
+    POLICY_CHECK_REQUESTED,
+    POLICY_DECISION_RECORDED,
+    POLICY_ESCALATION_CREATED,
+    // Human
+    HUMAN_GUIDANCE_ADDED,
+    HUMAN_CONSTRAINT_ADDED,
+    HUMAN_REVIEW_COMMENT_ADDED,
+    HUMAN_APPROVED,
+    HUMAN_REQUESTED_CHANGES,
+    HUMAN_PAUSED_AGENT,
+    HUMAN_RESUMED_AGENT,
+    HUMAN_MERGE_REQUESTED,
+    // Merge / release
+    AIVCS_MERGE_GUARDRAILS_STARTED,
+    AIVCS_MERGE_BLOCKED,
+    AIVCS_MERGE_COMPLETED,
+    AIVCS_RELEASE_CREATED,
+];
+
+/// AIVCS-owned event_type namespace prefixes.
+///
+/// An event_type belongs to the AIVCS taxonomy if it starts with any of these
+/// prefixes. This is informational only — it is NOT used as a runtime gate.
+/// Callers may use it for auditing, dashboards, or routing.
+const AIVCS_PREFIXES: &[&str] = &[
+    "aivcs.",
+    "agent.intent.",
+    "agent.plan.",
+    "agent.tool.",
+    "agent.confidence.",
+    "agent.risk.",
+    "ci.check.",
+    "policy.",
+    "human.",
+];
+
+/// Returns true if `event_type` belongs to the AIVCS taxonomy.
+///
+/// Informational only — do not use as an authorization gate or as a
+/// validation step on inbound events. The set of AIVCS-owned namespaces is
+/// fixed by issue #148.
+pub fn is_aivcs_event(event_type: &str) -> bool {
+    AIVCS_PREFIXES.iter().any(|p| event_type.starts_with(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn every_constant_is_unique() {
+        let set: HashSet<&&str> = ALL.iter().collect();
+        assert_eq!(
+            set.len(),
+            ALL.len(),
+            "duplicate event_type constants in ALL: {:?}",
+            ALL
+        );
+    }
+
+    #[test]
+    fn every_constant_follows_dot_lowercase_pattern() {
+        for c in ALL {
+            assert!(
+                !c.is_empty(),
+                "constant must not be empty"
+            );
+            assert!(
+                c.contains('.'),
+                "constant {:?} must contain at least one '.'",
+                c
+            );
+            assert!(
+                !c.chars().any(|ch| ch.is_whitespace()),
+                "constant {:?} must not contain whitespace",
+                c
+            );
+            assert!(
+                !c.chars().any(|ch| ch.is_ascii_uppercase()),
+                "constant {:?} must not contain uppercase ASCII",
+                c
+            );
+            // Reject any non-ASCII to keep grep simple.
+            assert!(
+                c.is_ascii(),
+                "constant {:?} must be ASCII",
+                c
+            );
+            // No leading or trailing dot, and no empty segments.
+            assert!(
+                !c.starts_with('.') && !c.ends_with('.'),
+                "constant {:?} must not start or end with '.'",
+                c
+            );
+            for seg in c.split('.') {
+                assert!(
+                    !seg.is_empty(),
+                    "constant {:?} must not contain empty dot-separated segments",
+                    c
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn is_aivcs_event_true_for_every_constant() {
+        for c in ALL {
+            assert!(
+                is_aivcs_event(c),
+                "is_aivcs_event returned false for canonical constant {:?}",
+                c
+            );
+        }
+    }
+
+    #[test]
+    fn is_aivcs_event_false_for_non_aivcs_event_types() {
+        // These are known non-AIVCS event types from the existing WS2/MCP
+        // taxonomy. They must NOT match the AIVCS prefixes.
+        let non_aivcs = [
+            "run.created",
+            "run.completed",
+            "task.created",
+            "plan.created",
+            "tool_call.completed",
+            "artifact.stored",
+            "release.created",
+            "checkpoint.taken",
+            "graph.event",
+            "",
+            "aivcs", // missing trailing dot — should not match prefix "aivcs."
+            "agent", // bare "agent" is not an AIVCS-owned namespace
+            "agent.other.thing", // "agent.other." is not one of the AIVCS sub-namespaces
+            "ci.other.thing",    // only "ci.check." is AIVCS-owned
+        ];
+        for ev in non_aivcs {
+            assert!(
+                !is_aivcs_event(ev),
+                "is_aivcs_event returned true for non-AIVCS event {:?}",
+                ev
+            );
+        }
+    }
+
+    /// Snapshot: prints every constant in declaration order so a future
+    /// contributor can `cargo test -- --nocapture event_taxonomy_snapshot`
+    /// and grep the taxonomy. Acts as a checked inventory: if a constant is
+    /// removed from ALL but kept in source, this test still runs against
+    /// whatever ALL contains.
+    #[test]
+    fn event_taxonomy_snapshot() {
+        let mut out = String::new();
+        out.push_str("AIVCS event taxonomy (issue #148):\n");
+        for c in ALL {
+            out.push_str(c);
+            out.push('\n');
+        }
+        // Print for `--nocapture` consumers.
+        println!("{}", out);
+        // Pin the count so accidental removals fail loudly. Update this
+        // number deliberately when adding/removing constants.
+        assert_eq!(ALL.len(), 31, "ALL count changed; update the snapshot");
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -37,6 +37,13 @@ pub mod aivcs;
 #[allow(dead_code)]
 pub mod aivcs_review;
 
+// AIVCS event taxonomy constants (issue #148, slice 5).
+// Namespaced — no glob re-export — callers reference as `models::aivcs_events::*`.
+// Constants are pre-declared for downstream slices; suppress dead_code until
+// callers are wired up.
+#[allow(dead_code)]
+pub mod aivcs_events;
+
 pub use entities::*;
 pub use memory::*;
 pub use orchestration::*;


### PR DESCRIPTION
**Slice 5 of #148** — _Event taxonomy for AIVCS_.

Draft — opened for review.

Refs #148 (partial — the parent design issue stays open until all 6 wave-1 slices land).

## Why

Per the "Event taxonomy for AIVCS" section of #148, AIVCS introduces a new family of `event_type` values that span repository sync, agent reasoning, CI, policy, human-in-the-loop, and merge/release. Today those would be inline string literals at every call site, which is typo-prone and gives reviewers no single grep target to audit which event types AIVCS expects.

This slice declares those events as first-class Rust constants so:
- Callers get typo-safe, namespaced references (`models::aivcs_events::AIVCS_REVIEW_OPENED`) instead of string literals.
- Reviewers can audit the AIVCS surface from one file.
- Downstream slices (projections, allowlists, dashboards) can iterate over `ALL` instead of redeclaring the list.

## What landed

- **New module** `src/models/aivcs_events` with **31** public `&str` constants across the six AIVCS namespaces:
  - AIVCS lifecycle: `aivcs.repository.synced`, `aivcs.branch.created`, `aivcs.commit.ingested`, `aivcs.change_set.proposed`, `aivcs.diff.artifact_stored`, `aivcs.review.opened`, `aivcs.review_thread.created`
  - Agent: `agent.intent.recorded`, `agent.plan.created`, `agent.tool.requested`, `agent.tool.completed`, `agent.confidence.updated`, `agent.risk.updated`
  - CI: `ci.check.started`, `ci.check.completed`, `ci.check.failed`
  - Policy: `policy.check.requested`, `policy.decision.recorded`, `policy.escalation.created`
  - Human: `human.guidance.added`, `human.constraint.added`, `human.review.comment_added`, `human.approved`, `human.requested_changes`, `human.paused_agent`, `human.resumed_agent`, `human.merge_requested`
  - Merge / release: `aivcs.merge.guardrails_started`, `aivcs.merge.blocked`, `aivcs.merge.completed`, `aivcs.release.created`
- `ALL: &[&str]` — every constant in stable declaration order, for documentation, snapshots, and future allowlisting.
- `is_aivcs_event(&str) -> bool` — informational helper returning `true` for any `event_type` starting with an AIVCS-owned namespace prefix (`aivcs.`, `agent.intent.`, `agent.plan.`, `agent.tool.`, `agent.confidence.`, `agent.risk.`, `ci.check.`, `policy.`, `human.`). **Not** used as a runtime gate.
- Wired into `src/models/mod.rs` as `pub mod aivcs_events` — namespaced, **no glob re-export**. Callers must use `models::aivcs_events::*` explicitly.
- Unit tests:
  - Every constant unique (`HashSet` size == `ALL.len()`).
  - Every constant matches the dot-separated lowercase ASCII pattern (no whitespace, no uppercase, no empty segments, no leading/trailing dot, contains at least one `.`).
  - `is_aivcs_event` returns `true` for every canonical constant.
  - `is_aivcs_event` returns `false` for known non-AIVCS event types (`run.created`, `task.created`, `plan.created`, `tool_call.completed`, `artifact.stored`, `release.created`, `checkpoint.taken`, `graph.event`, bare `aivcs`, bare `agent`, out-of-scope `agent.other.thing`, `ci.other.thing`, empty string).
  - Snapshot test that prints every constant in declaration order and pins the count (31) so accidental removals fail loudly.

## Scope notes — what is NOT in this slice

The #148 design doc has many sub-scopes; this slice is **taxonomy declaration only**.

- **No** validation of `event_type` against this list in `IngestEvent`. The "whitelist vs allow-anything" decision is deliberately deferred to a separate slice under #148.
- **No** HTTP routes, no new endpoints, no projections or read-models.
- **No** SurrealDB / D1 migrations.
- **No** Durable Object handlers, no wrangler config changes, no queue bindings.
- **No** policy/CI/human integration logic — only the constants those subsystems will reference later.
- **No** documentation site changes (slice 0 territory).
- `is_aivcs_event` is **informational only** — explicitly documented as not a gate. Callers must not depend on it for authorization or input validation.

## Verification

All commands run with `-D warnings`:

| Command | Result |
| --- | --- |
| `RUSTFLAGS="-D warnings" cargo check --target wasm32-unknown-unknown -p data-fabric-worker` | clean |
| `RUSTFLAGS="-D warnings --cfg=coverage" cargo check --tests -p data-fabric-worker` | clean |
| `cargo test -p data-fabric-worker --lib` | **396 passed**, 0 failed — including 5 new `models::aivcs_events::tests::*` |

New tests:
- `models::aivcs_events::tests::every_constant_is_unique`
- `models::aivcs_events::tests::every_constant_follows_dot_lowercase_pattern`
- `models::aivcs_events::tests::is_aivcs_event_true_for_every_constant`
- `models::aivcs_events::tests::is_aivcs_event_false_for_non_aivcs_event_types`
- `models::aivcs_events::tests::event_taxonomy_snapshot`