### PR TITLE
docs(aivcs): standardize integration on /v1/* (drop /fabric/* references)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,9 +16,11 @@ Increase velocity for orchestrated autonomous AI agent builders through:
 
 ### 1. Edge API (Cloudflare Workers, Rust)
 - `/health`
-- `/fabric/ingest`
-- `/fabric/query`
-- `/fabric/plays/{play}/launch`
+- `/v1/events` (single-event ingest)
+- `/v1/runs/:run_id/tasks` (run-scoped task ingest)
+- `/v1/traces/:run_id` (per-run trace / provenance query)
+- `/v1/runs/:run_id/summary` (gold-layer run summary)
+- `/v1/plays/:name/launch`
 - `/mcp/task/next`
 - `/mcp/response`
 

--- a/docs/INTEGRATION_OXIDIZEDGRAPH.md
+++ b/docs/INTEGRATION_OXIDIZEDGRAPH.md
@@ -105,7 +105,7 @@ impl FabricPersister {
     /// Record a node execution event
     pub async fn record_event(
         &self,
-        node_type: &str,
+        actor: &str,
         event_type: &str,
         payload: serde_json::Value,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -113,15 +113,15 @@ impl FabricPersister {
 
         let event = json!({
             "event_type": event_type,
-            "node_type": node_type,
             "run_id": self.run_id,
-            "tenant_id": self.tenant_id,
+            "actor": actor,
             "payload": payload,
         });
 
         self.client
             .post(&url)
             .header("X-Tenant-ID", &self.tenant_id)
+            .header("X-Tenant-Role", "admin")
             .header("Content-Type", "application/json")
             .json(&event)
             .send()
@@ -177,7 +177,7 @@ mod tests {
 
         // This will fail until data-fabric is running
         let result = persister
-            .record_event("governance", "node_executed", payload)
+            .record_event("governance-node", "node_executed", payload)
             .await;
 
         println!("Result: {:?}", result);
@@ -486,6 +486,7 @@ just dev-worker
 ```http
 POST /v1/events
 X-Tenant-ID: <tenant>
+X-Tenant-Role: admin
 
 {
   "run_id": "run_xxx",

--- a/docs/INTEGRATION_OXIDIZEDGRAPH.md
+++ b/docs/INTEGRATION_OXIDIZEDGRAPH.md
@@ -109,7 +109,7 @@ impl FabricPersister {
         event_type: &str,
         payload: serde_json::Value,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let url = format!("{}/fabric/ingest", self.fabric_url);
+        let url = format!("{}/v1/events", self.fabric_url);
 
         let event = json!({
             "event_type": event_type,
@@ -130,24 +130,23 @@ impl FabricPersister {
         Ok(())
     }
 
-    /// Retrieve context for decision-making
+    /// Retrieve context for decision-making.
+    ///
+    /// Uses the per-run trace view `GET /v1/traces/:run_id`. For
+    /// memory-style retrieval use `POST /v1/memory/retrieve`; for full
+    /// lineage use `GET /v1/traces/:run_id/lineage`. `query_type` and
+    /// `filters` are retained on the client signature for backward
+    /// compatibility but are not sent on the wire by this endpoint.
     pub async fn query_context(
         &self,
-        query_type: &str,
-        filters: serde_json::Value,
+        _query_type: &str,
+        _filters: serde_json::Value,
     ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-        let url = format!("{}/fabric/query", self.fabric_url);
-
-        let query = json!({
-            "query_type": query_type,
-            "filters": filters,
-        });
+        let url = format!("{}/v1/traces/{}", self.fabric_url, self.run_id);
 
         let response = self.client
-            .post(&url)
+            .get(&url)
             .header("X-Tenant-ID", &self.tenant_id)
-            .header("Content-Type", "application/json")
-            .json(&query)
             .send()
             .await?
             .json()
@@ -438,13 +437,13 @@ data-fabric requires tenant headers:
 
 ```rust
 // ❌ Wrong - will get 401
-client.post("http://localhost:8787/fabric/ingest")
+client.post("http://localhost:8787/v1/events")
     .json(&event)
     .send()
     .await?
 
 // ✅ Correct
-client.post("http://localhost:8787/fabric/ingest")
+client.post("http://localhost:8787/v1/events")
     .header("X-Tenant-ID", "test-tenant")
     .header("X-Tenant-Role", "admin")
     .json(&event)
@@ -485,27 +484,31 @@ just dev-worker
 ### Record Event
 
 ```http
-POST /fabric/ingest
+POST /v1/events
 X-Tenant-ID: <tenant>
 
 {
-  "event_type": "node_executed|tool_called|task_completed",
   "run_id": "run_xxx",
-  "payload": { ... }
+  "event_type": "node_executed|tool_called|task_completed",
+  "actor": "governance-node",
+  "entity_kind": "task",          // optional
+  "entity_id": "task_xxx",        // optional
+  "payload": { ... }              // optional
 }
 ```
 
-### Query Context
+### Query Context (per-run trace / provenance)
 
 ```http
-POST /fabric/query
+GET /v1/traces/:run_id?limit=100
 X-Tenant-ID: <tenant>
-
-{
-  "query_type": "memory|lineage|compliance",
-  "filters": { "run_id": "run_xxx", "role": "architect" }
-}
 ```
+
+Related queries:
+
+- `GET /v1/traces/:run_id/lineage` — full lineage view for a run
+- `GET /v1/runs/:run_id/summary` — gold-layer run summary
+- `POST /v1/memory/retrieve` — semantic + filtered memory retrieval
 
 ### Health Check
 

--- a/docs/LOCAL_DEPLOYMENT.md
+++ b/docs/LOCAL_DEPLOYMENT.md
@@ -236,6 +236,7 @@ X-Tenant-Role: admin|member
 ```http
 POST /v1/events
 X-Tenant-ID: <tenant-id>
+X-Tenant-Role: admin
 
 {
   "run_id": "run_xxx",

--- a/docs/LOCAL_DEPLOYMENT.md
+++ b/docs/LOCAL_DEPLOYMENT.md
@@ -234,27 +234,31 @@ X-Tenant-Role: admin|member
 #### Ingest Event
 
 ```http
-POST /fabric/ingest
+POST /v1/events
 X-Tenant-ID: <tenant-id>
 
 {
-  "event_type": "tool_called|tool_returned|task_started",
   "run_id": "run_xxx",
-  "payload": { ... }
+  "event_type": "tool_called|tool_returned|task_started",
+  "actor": "<actor>",
+  "entity_kind": "task",          // optional
+  "entity_id": "task_xxx",        // optional
+  "payload": { ... }              // optional
 }
 ```
 
-#### Query Context
+#### Query Context (per-run trace)
 
 ```http
-POST /fabric/query
+GET /v1/traces/:run_id?limit=100
 X-Tenant-ID: <tenant-id>
-
-{
-  "query_type": "memory|lineage|artifact",
-  "filters": { "run_id": "run_xxx" }
-}
 ```
+
+Related queries:
+
+- `GET /v1/traces/:run_id/lineage` — full lineage view
+- `GET /v1/runs/:run_id/summary` — gold-layer run summary
+- `POST /v1/memory/retrieve` — semantic + filtered memory retrieval (use this for memory queries)
 
 ---
 


### PR DESCRIPTION
**Slice 0** of #148 (aivcs wave-1 integration). Refs #148 — partial, not closes; the parent issue stays open until all 6 wave-1 slices land.

**Draft — opened for review.**

## Why

Per #148's "honest current-state note", the integration docs advertise `/fabric/ingest`, `/fabric/query`, and `/fabric/plays/{play}/launch`, but **none of those routes exist** in `src/lib.rs`. The actual worker exposes the `/v1/*` family. This documentation drift is a blocker for downstream integrators (aivcs, oxidizedgraph) trying to wire up against the real surface.

## What landed

Pure docs update. Every `/fabric/*` reference in scope is replaced with the actual implemented route, validated against `src/lib.rs` handlers.

Mapping applied (chosen per call-site context):

| Old (drift)                    | New (per `src/lib.rs`)                                                                                          |
|--------------------------------|------------------------------------------------------------------------------------------------------------------|
| `POST /fabric/ingest`          | `POST /v1/events` (matches `models::IngestEvent`: `run_id` + `event_type` + `actor` + optional entity/payload)   |
| `POST /fabric/query`           | `GET /v1/traces/:run_id` (with cross-refs to `/v1/traces/:run_id/lineage`, `/v1/runs/:run_id/summary`, `/v1/memory/retrieve`) |
| `POST /fabric/plays/{play}/launch` | `POST /v1/plays/:name/launch`                                                                              |

Files touched:

- `docs/ARCHITECTURE.md` — Edge API route list
- `docs/INTEGRATION_OXIDIZEDGRAPH.md` — `FabricPersister` example code, troubleshooting snippets, API Reference section
- `docs/LOCAL_DEPLOYMENT.md` — API Reference section

Note: `examples/` does not exist in this repo, and `README.md` had no `/fabric/` references.

## Verification

```
$ grep -rn '/fabric/' docs/ README.md
$ echo $?
1     # no matches
```

Per the slice spec, Rust verification (`cargo check`/`cargo test`) is **skipped for slice 0** because this is docs-only — no source touched, no schema/migration touched, no routes added.

## Scope (explicit boundaries)

**In scope (this slice):**
- Docs-only rewrite of `/fabric/*` -> correct `/v1/*` routes.
- Aligning the example `IngestEvent` body with the real `models::IngestEvent` shape (added `actor`, `entity_kind`, `entity_id` as optional in the request examples).

**NOT in this slice (deferred to later wave-1 slices of #148):**
- No new routes added — strictly drift correction.
- No source code changes (`src/**`, `migrations/**`, `wrangler.toml`, `Cargo.toml` untouched).
- No schema or migration changes.
- No aivcs-specific integration code (slice 1+).
- No SDK / `data-fabric-client` updates (separate slice).
- No `mcp-server` changes (separate slice).
- No tests added — pure docs.
- The `/fabric/query` -> `/v1/traces/:run_id` mapping covers the doc's `lineage`/`compliance` `query_type`; doc readers wanting `memory`-style retrieval are pointed to `/v1/memory/retrieve` in the same section but the migration of any actual memory consumer is **out of scope here**.

## Risk

Low. Documentation-only; no runtime behavior changes; no migration; no API surface change. Worst case is that this PR is reverted with zero blast radius.

---

Refs #148

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>