### PR TITLE
feat(aivcs): add change_set projection (entity above diff artifact)

### DIFF
--- a/migrations/0015_aivcs_change_set.sql
+++ b/migrations/0015_aivcs_change_set.sql
@@ -1,0 +1,37 @@
+-- AIVCS slice 1: native `change_set` entity (the projection above the diff
+-- artifact). Per issue #148 ("AIVCS UI as a human-facing control plane on
+-- top of data-fabric"), AIVCS needs a first-class entity that represents a
+-- proposed change — an agent's PR-equivalent — with status, risk, confidence,
+-- and pointers to the diff/summary artifacts in R2 (`*_artifact_key`) and the
+-- originating run (`run_id`).
+--
+-- The issue notes this concept "can begin as Run.metadata.aivcs.change_set,
+-- then graduate into a table". This migration is that graduation: a stand-
+-- alone, multi-tenant-safe projection table with tenant_id as the leading
+-- column of the composite PRIMARY KEY (consistent with the WS8 isolation
+-- model — see 0005_ws8_multi_tenant.sql, 0014_ws8_tenant_id_addendum.sql).
+--
+-- Scope of this slice: projection + types + DB layer only. HTTP routes
+-- (POST/GET /v1/aivcs/change-sets), gold read-models, and the BFF surface
+-- are explicitly out of scope and land in subsequent slices.
+
+CREATE TABLE IF NOT EXISTS change_set (
+  tenant_id TEXT NOT NULL DEFAULT '',
+  id TEXT NOT NULL,
+  repo TEXT NOT NULL,
+  base_ref TEXT NOT NULL,
+  head_ref TEXT NOT NULL,
+  author_agent_id TEXT,
+  status TEXT NOT NULL DEFAULT 'proposed', -- proposed | reviewing | approved | merged | abandoned
+  risk_level TEXT,                          -- low | medium | high | critical
+  confidence REAL,                          -- 0.0..1.0
+  run_id TEXT,
+  diff_artifact_key TEXT,
+  summary_artifact_key TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (tenant_id, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_change_set_tenant_repo ON change_set(tenant_id, repo);
+CREATE INDEX IF NOT EXISTS idx_change_set_tenant_status ON change_set(tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_change_set_run_id ON change_set(tenant_id, run_id);

--- a/src/db.rs
+++ b/src/db.rs
@@ -33,6 +33,33 @@ const SQL_SELECT_RATE_LIMIT_COUNT: &str =
     "SELECT count FROM policy_rate_limit_counters \
      WHERE tenant_id = ?1 AND id = ?2";
 
+// ── AIVCS: change_set SQL constants (issue #148, slice 1) ──────────
+//
+// The `change_set` table is the projection AIVCS uses above the diff
+// artifact (R2). All three statements below bind `tenant_id` as `?1`
+// so cross-tenant reads/writes are impossible — the
+// `cross_tenant_sql_change_set_*` tests in `mod tests` pin this.
+
+/// INSERT into `change_set`. tenant_id is the first column and ?1.
+pub const SQL_INSERT_CHANGE_SET: &str =
+    "INSERT INTO change_set (tenant_id, id, repo, base_ref, head_ref, author_agent_id, status, risk_level, confidence, run_id, diff_artifact_key, summary_artifact_key) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)";
+
+/// SELECT a single `change_set` row by (tenant_id, id).
+pub const SQL_GET_CHANGE_SET: &str =
+    "SELECT id, repo, base_ref, head_ref, author_agent_id, status, risk_level, confidence, run_id, diff_artifact_key, summary_artifact_key, created_at \
+     FROM change_set \
+     WHERE tenant_id = ?1 AND id = ?2";
+
+/// SELECT recent `change_set` rows for a repo. ORDER BY created_at DESC,
+/// LIMIT is bound as `?3` so callers can page (cursor-based pagination
+/// lands with the HTTP route in a later slice).
+pub const SQL_LIST_CHANGE_SETS_BY_REPO: &str =
+    "SELECT id, repo, base_ref, head_ref, author_agent_id, status, risk_level, confidence, run_id, diff_artifact_key, summary_artifact_key, created_at \
+     FROM change_set \
+     WHERE tenant_id = ?1 AND repo = ?2 \
+     ORDER BY created_at DESC \
+     LIMIT ?3";
+
 pub fn now_iso() -> String {
     js_sys::Date::new_0().to_iso_string().as_string().unwrap()
 }
@@ -3686,6 +3713,152 @@ impl IntegrationRow {
     }
 }
 
+// ── AIVCS: change_set DB layer (issue #148, slice 1) ───────────────
+//
+// Projection above the diff artifact — see `migrations/0015_aivcs_change_set.sql`
+// and `models/aivcs.rs`. HTTP routes land in a later slice; this file only
+// owns the SQL + (tenant_id, ...) parameter wiring.
+
+/// Storage-string form of a [`RiskLevel`]. `RiskLevel` is `#[serde(rename_all =
+/// "snake_case")]`, so serializing yields a quoted JSON string (`"\"low\""`);
+/// strip the quotes to get the bare token we persist in the `risk_level` column.
+fn risk_level_storage_str(risk: RiskLevel) -> String {
+    // Serializing a Copy enum to JSON cannot fail — unwrap surfaces any
+    // future serde-attribute regression instead of silently writing "".
+    let s = serde_json::to_string(&risk).expect("RiskLevel always serializes");
+    s.trim_matches('"').to_string()
+}
+
+/// Reverse of [`risk_level_storage_str`].
+fn risk_level_from_storage_str(s: &str) -> Option<RiskLevel> {
+    serde_json::from_str(&format!("\"{s}\"")).ok()
+}
+
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+#[derive(Debug, serde::Deserialize)]
+struct ChangeSetRow {
+    id: String,
+    repo: String,
+    base_ref: String,
+    head_ref: String,
+    author_agent_id: Option<String>,
+    status: String,
+    risk_level: Option<String>,
+    confidence: Option<f64>,
+    run_id: Option<String>,
+    diff_artifact_key: Option<String>,
+    summary_artifact_key: Option<String>,
+    created_at: String,
+}
+
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+impl ChangeSetRow {
+    fn into_change_set(self) -> models::ChangeSet {
+        let status = std::str::FromStr::from_str(&self.status)
+            .unwrap_or(models::ChangeSetStatus::Proposed);
+        let risk_level = self.risk_level.as_deref().and_then(risk_level_from_storage_str);
+        models::ChangeSet {
+            id: self.id,
+            repo: self.repo,
+            base_ref: self.base_ref,
+            head_ref: self.head_ref,
+            author_agent_id: self.author_agent_id,
+            status,
+            risk_level,
+            confidence: self.confidence,
+            run_id: self.run_id,
+            diff_artifact_key: self.diff_artifact_key,
+            summary_artifact_key: self.summary_artifact_key,
+            created_at: self.created_at,
+        }
+    }
+}
+
+/// Insert a new `change_set` row. If `cs.id` is None, a random hex id is
+/// minted (consistent with how other entities in this file generate ids).
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+pub async fn create_change_set(
+    d1: &D1Database,
+    tenant_id: &str,
+    cs: &models::CreateChangeSet,
+) -> Result<models::ChangeSet> {
+    let id = match cs.id.as_deref() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => random_hex_id()?,
+    };
+    let status = cs.status.unwrap_or(models::ChangeSetStatus::Proposed);
+    let status_str = status.as_str();
+    let risk_level_str = cs.risk_level.map(risk_level_storage_str);
+    let now = now_iso();
+
+    d1.prepare(SQL_INSERT_CHANGE_SET)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(&id),
+            JsValue::from_str(&cs.repo),
+            JsValue::from_str(&cs.base_ref),
+            JsValue::from_str(&cs.head_ref),
+            opt_str(&cs.author_agent_id),
+            JsValue::from_str(status_str),
+            opt_str(&risk_level_str),
+            cs.confidence.map(JsValue::from).unwrap_or(JsValue::NULL),
+            opt_str(&cs.run_id),
+            opt_str(&cs.diff_artifact_key),
+            opt_str(&cs.summary_artifact_key),
+        ])?
+        .run()
+        .await?;
+
+    Ok(models::ChangeSet {
+        id,
+        repo: cs.repo.clone(),
+        base_ref: cs.base_ref.clone(),
+        head_ref: cs.head_ref.clone(),
+        author_agent_id: cs.author_agent_id.clone(),
+        status,
+        risk_level: cs.risk_level,
+        confidence: cs.confidence,
+        run_id: cs.run_id.clone(),
+        diff_artifact_key: cs.diff_artifact_key.clone(),
+        summary_artifact_key: cs.summary_artifact_key.clone(),
+        created_at: now,
+    })
+}
+
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+pub async fn get_change_set(
+    d1: &D1Database,
+    tenant_id: &str,
+    id: &str,
+) -> Result<Option<models::ChangeSet>> {
+    let row: Option<ChangeSetRow> = d1
+        .prepare(SQL_GET_CHANGE_SET)
+        .bind(&[JsValue::from_str(tenant_id), JsValue::from_str(id)])?
+        .first(None)
+        .await?;
+    Ok(row.map(|r| r.into_change_set()))
+}
+
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+pub async fn list_change_sets_by_repo(
+    d1: &D1Database,
+    tenant_id: &str,
+    repo: &str,
+    limit: u32,
+) -> Result<Vec<models::ChangeSet>> {
+    let result: D1Result = d1
+        .prepare(SQL_LIST_CHANGE_SETS_BY_REPO)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(repo),
+            JsValue::from(limit as f64),
+        ])?
+        .all()
+        .await?;
+    let rows: Vec<ChangeSetRow> = result.results()?;
+    Ok(rows.into_iter().map(|r| r.into_change_set()).collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3966,6 +4139,93 @@ mod tests {
         let a = rate_limit_counter_id("tenant-alpha", "shared-actor", "write", 0, 60);
         let b = rate_limit_counter_id("tenant-beta", "shared-actor", "write", 0, 60);
         assert_ne!(a, b);
+    }
+
+    // ── AIVCS: change_set cross-tenant SQL shape (issue #148, slice 1) ─
+
+    #[test]
+    fn cross_tenant_sql_insert_change_set_writes_tenant_id_at_position_1() {
+        // The INSERT must bind `tenant_id` to ?1 and list it as the first
+        // column. Without that, an agent writing under tenant A could be
+        // surfaced to tenant B by the get/list helpers. The exact column-
+        // list-and-VALUES shape is asserted because this is the
+        // authoritative SQL that runs against D1.
+        let sql = SQL_INSERT_CHANGE_SET;
+        assert!(
+            sql.contains("INTO change_set"),
+            "insert SQL must target change_set; got: {sql}",
+        );
+        let col_list_start = sql.find("change_set (").expect("expected column list");
+        let col_list_tail = &sql[col_list_start..];
+        assert!(
+            col_list_tail.starts_with("change_set (tenant_id, id,"),
+            "tenant_id must be the first column of the INSERT list; got: {col_list_tail}",
+        );
+        assert!(
+            sql.contains("VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)"),
+            "insert SQL must bind tenant_id as ?1 and 12 total params; got: {sql}",
+        );
+    }
+
+    #[test]
+    fn cross_tenant_sql_get_change_set_filters_on_tenant_id_first() {
+        // The SELECT must include `tenant_id = ?1` in the WHERE clause,
+        // and tenant_id must be the FIRST predicate so an EXPLAIN cannot
+        // accidentally pick an index that ignores the tenant dimension.
+        let sql = SQL_GET_CHANGE_SET;
+        assert!(
+            sql.contains("FROM change_set"),
+            "get SQL must target change_set; got: {sql}",
+        );
+        assert!(
+            sql.contains("WHERE tenant_id = ?1 AND id = ?2"),
+            "get SQL must filter by tenant_id (?1) then id (?2); got: {sql}",
+        );
+    }
+
+    #[test]
+    fn cross_tenant_sql_list_change_sets_by_repo_filters_on_tenant_id_first() {
+        let sql = SQL_LIST_CHANGE_SETS_BY_REPO;
+        assert!(
+            sql.contains("FROM change_set"),
+            "list SQL must target change_set; got: {sql}",
+        );
+        assert!(
+            sql.contains("WHERE tenant_id = ?1 AND repo = ?2"),
+            "list SQL must filter by tenant_id (?1) then repo (?2); got: {sql}",
+        );
+        assert!(
+            sql.contains("ORDER BY created_at DESC"),
+            "list SQL must return newest-first; got: {sql}",
+        );
+        assert!(
+            sql.contains("LIMIT ?3"),
+            "list SQL must bind limit as ?3; got: {sql}",
+        );
+    }
+
+    #[test]
+    fn change_set_risk_level_round_trips_through_storage_str() {
+        // The risk_level column stores the snake_case token (low | medium |
+        // high | critical). Both directions must round-trip so reads after
+        // a write produce an equal RiskLevel.
+        let levels = [
+            RiskLevel::Low,
+            RiskLevel::Medium,
+            RiskLevel::High,
+            RiskLevel::Critical,
+        ];
+        for r in levels {
+            let s = risk_level_storage_str(r);
+            assert!(
+                !s.contains('"'),
+                "stored risk_level must be a bare token, not quoted JSON; got: {s}",
+            );
+            let back = risk_level_from_storage_str(&s).expect("known risk_level must parse");
+            assert_eq!(back, r);
+        }
+        assert_eq!(risk_level_storage_str(RiskLevel::Low), "low");
+        assert!(risk_level_from_storage_str("not-a-risk").is_none());
     }
 
     #[test]

--- a/src/models/aivcs.rs
+++ b/src/models/aivcs.rs
@@ -1,0 +1,264 @@
+//! AIVCS — Slice 1: native `change_set` projection.
+//!
+//! Per issue #148 ("AIVCS UI as a human-facing control plane on top of
+//! data-fabric"), AIVCS needs an entity above "diff artifact" that
+//! represents a proposed change with metadata (status, risk, confidence,
+//! and pointers to the diff/summary artifacts in R2).
+//!
+//! This module is intentionally narrow:
+//!   • [`ChangeSet`]       — the read shape returned to callers / serialized
+//!                           back from the D1 row.
+//!   • [`CreateChangeSet`] — the creation payload accepted by the DB layer.
+//!                           `id` is auto-generated if omitted (see
+//!                           `db::create_change_set`).
+//!   • [`ChangeSetStatus`] — typed enum for the `status` column, with the
+//!                           five canonical lifecycle states.
+//!
+//! `RiskLevel` is *not* re-defined here; it already lives in [`crate::policy`]
+//! with the same snake_case serde shape. We re-export it so callers using
+//! `models::*` get a coherent surface without having to reach into the
+//! policy module.
+//!
+//! ## Scope
+//! Projection + types + DB layer only. HTTP routes and gold read-models
+//! land in subsequent AIVCS slices.
+
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+// Re-export the canonical RiskLevel so AIVCS callers can write
+// `models::RiskLevel` instead of reaching into `crate::policy`.
+pub use crate::policy::RiskLevel;
+
+/// Lifecycle state of a [`ChangeSet`]. Mirrors the `status` column in the
+/// `change_set` table (migration `0015_aivcs_change_set.sql`).
+///
+/// The transitions sketched by issue #148:
+/// `Proposed → Reviewing → Approved → Merged`, with `Abandoned` as the
+/// terminal "rejected/withdrawn" branch from any non-merged state.
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeSetStatus {
+    Proposed,
+    Reviewing,
+    Approved,
+    Merged,
+    Abandoned,
+}
+
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+impl ChangeSetStatus {
+    /// Storage-string form of the status. Matches the values written by
+    /// the SQL `DEFAULT 'proposed'` clause and by `db::create_change_set`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Proposed => "proposed",
+            Self::Reviewing => "reviewing",
+            Self::Approved => "approved",
+            Self::Merged => "merged",
+            Self::Abandoned => "abandoned",
+        }
+    }
+}
+
+impl FromStr for ChangeSetStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "proposed" => Ok(Self::Proposed),
+            "reviewing" => Ok(Self::Reviewing),
+            "approved" => Ok(Self::Approved),
+            "merged" => Ok(Self::Merged),
+            "abandoned" => Ok(Self::Abandoned),
+            other => Err(format!("unknown change_set status: {other}")),
+        }
+    }
+}
+
+/// Read shape of a row in the `change_set` table. Returned by the DB layer
+/// and serialized over the wire (snake_case JSON, matching the column
+/// names in the migration).
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChangeSet {
+    pub id: String,
+    pub repo: String,
+    pub base_ref: String,
+    pub head_ref: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author_agent_id: Option<String>,
+
+    pub status: ChangeSetStatus,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_level: Option<RiskLevel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff_artifact_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary_artifact_key: Option<String>,
+
+    pub created_at: String,
+}
+
+/// Creation payload. `id` is optional — if omitted, the DB layer mints a
+/// random hex id (same generator used by other entities). `status` defaults
+/// to [`ChangeSetStatus::Proposed`] when omitted, matching the SQL DEFAULT.
+#[allow(dead_code)] // HTTP route consumer lands in a later AIVCS slice.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CreateChangeSet {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    pub repo: String,
+    pub base_ref: String,
+    pub head_ref: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author_agent_id: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<ChangeSetStatus>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub risk_level: Option<RiskLevel>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff_artifact_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary_artifact_key: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn change_set_status_round_trips_str_to_enum_to_str_for_all_variants() {
+        // Every variant of the lifecycle enum must round-trip through its
+        // storage-string form. If a new variant is added to the enum but the
+        // as_str / FromStr branches are not updated, this test will fail —
+        // catching it before a row hits D1 with an unmappable status.
+        let all = [
+            ChangeSetStatus::Proposed,
+            ChangeSetStatus::Reviewing,
+            ChangeSetStatus::Approved,
+            ChangeSetStatus::Merged,
+            ChangeSetStatus::Abandoned,
+        ];
+        for status in all {
+            let s = status.as_str();
+            let parsed = ChangeSetStatus::from_str(s).expect("known status must parse");
+            assert_eq!(parsed, status, "round-trip failed for {s}");
+            assert_eq!(parsed.as_str(), s);
+        }
+    }
+
+    #[test]
+    fn change_set_status_default_storage_string_is_proposed() {
+        // The SQL migration sets DEFAULT 'proposed' for the status column.
+        // If the enum's `Proposed` variant ever stops mapping to that
+        // literal, freshly inserted rows would deserialize incorrectly.
+        assert_eq!(ChangeSetStatus::Proposed.as_str(), "proposed");
+        assert_eq!(
+            ChangeSetStatus::from_str("proposed").unwrap(),
+            ChangeSetStatus::Proposed,
+        );
+    }
+
+    #[test]
+    fn change_set_status_rejects_unknown_storage_value() {
+        let err = ChangeSetStatus::from_str("rejected").expect_err("unknown variant must error");
+        assert!(err.contains("rejected"), "error must mention the bad value");
+    }
+
+    #[test]
+    fn change_set_round_trips_serde_json() {
+        let cs = ChangeSet {
+            id: "cs_abcdef".into(),
+            repo: "acme/checkout-service".into(),
+            base_ref: "main".into(),
+            head_ref: "feature/optimize-checkout".into(),
+            author_agent_id: Some("optimizer-7".into()),
+            status: ChangeSetStatus::Reviewing,
+            risk_level: Some(RiskLevel::Low),
+            confidence: Some(0.85),
+            run_id: Some("run_218".into()),
+            diff_artifact_key: Some("aivcs/change_set/cs_abcdef/diff.patch".into()),
+            summary_artifact_key: Some("aivcs/change_set/cs_abcdef/summary.md".into()),
+            created_at: "2026-06-11T12:00:00.000Z".into(),
+        };
+
+        let json = serde_json::to_string(&cs).expect("serialize");
+        let parsed: ChangeSet = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, cs);
+
+        // Spot-check the wire shape — snake_case keys, status as a string,
+        // and risk_level as a snake_case enum string (re-exported from
+        // crate::policy::RiskLevel).
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["status"], "reviewing");
+        assert_eq!(v["risk_level"], "low");
+        assert_eq!(v["repo"], "acme/checkout-service");
+    }
+
+    #[test]
+    fn change_set_round_trips_with_all_optional_fields_omitted() {
+        // Minimum-viable shape — every optional field is None. Verifies
+        // skip_serializing_if + default deserialization both work.
+        let cs = ChangeSet {
+            id: "cs_min".into(),
+            repo: "acme/svc".into(),
+            base_ref: "main".into(),
+            head_ref: "feature/x".into(),
+            author_agent_id: None,
+            status: ChangeSetStatus::Proposed,
+            risk_level: None,
+            confidence: None,
+            run_id: None,
+            diff_artifact_key: None,
+            summary_artifact_key: None,
+            created_at: "2026-06-11T12:00:00.000Z".into(),
+        };
+        let json = serde_json::to_string(&cs).unwrap();
+        // None fields must not appear in the serialized JSON.
+        assert!(!json.contains("author_agent_id"));
+        assert!(!json.contains("risk_level"));
+        assert!(!json.contains("confidence"));
+        assert!(!json.contains("run_id"));
+        assert!(!json.contains("diff_artifact_key"));
+        assert!(!json.contains("summary_artifact_key"));
+
+        let parsed: ChangeSet = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, cs);
+    }
+
+    #[test]
+    fn create_change_set_accepts_minimal_payload() {
+        // The minimum a caller must supply: repo + base_ref + head_ref.
+        // Everything else is optional and falls back to SQL defaults
+        // (id auto-generated; status defaults to 'proposed').
+        let json = r#"{
+            "repo": "acme/svc",
+            "base_ref": "main",
+            "head_ref": "feature/x"
+        }"#;
+        let payload: CreateChangeSet = serde_json::from_str(json).expect("parse minimal");
+        assert_eq!(payload.repo, "acme/svc");
+        assert!(payload.id.is_none());
+        assert!(payload.status.is_none());
+        assert!(payload.risk_level.is_none());
+        assert!(payload.confidence.is_none());
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -22,12 +22,16 @@ mod requests;
 // WS5 memory / retrieval.
 mod memory;
 
+// AIVCS — slice 1: native `change_set` projection (issue #148).
+pub mod aivcs;
+
 pub use entities::*;
 pub use memory::*;
 pub use orchestration::*;
 #[allow(unused_imports)]
 pub use relationships::*;
 pub use requests::*;
+pub use aivcs::{ChangeSet, ChangeSetStatus, CreateChangeSet};
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
**Refs #148** — slice 1 of 6 (wave-1). Partial; the parent issue stays open until all wave-1 slices land.

**Slice number:** 1 (source-of-truth pipeline — `change_set` projection only).

Draft — opened for review.

## Why

Issue #148 ("AIVCS UI as a human-facing control plane on top of data-fabric") calls out that AIVCS needs a native `change_set` concept — an entity above "diff artifact" that represents a proposed change with metadata (status, risk, confidence, run/artifact pointers). The issue notes it "can begin as `Run.metadata.aivcs.change_set`, then graduate into a table". This slice is that graduation.

Without a first-class projection above the diff artifact, AIVCS has to re-derive change state from raw events on every UI render and there is no place to attach risk / confidence / status / agent attribution. The projection unblocks the Slice 2 review-workspace read model and the Slice 3 human-guidance loop without committing to any specific HTTP surface yet.

## What landed

- `migrations/0015_aivcs_change_set.sql` — idempotent (`IF NOT EXISTS`) `change_set` table with composite PK `(tenant_id, id)` and three tenant-scoped indexes (`repo`, `status`, `run_id`), consistent with the WS8 isolation model (see 0005, 0014).
- `src/models/aivcs.rs` (new) — `ChangeSet`, `CreateChangeSet`, `ChangeSetStatus` enum (proposed | reviewing | approved | merged | abandoned) with `as_str` / `FromStr`. `RiskLevel` already lives in `crate::policy` with the same snake_case serde shape; it is **re-exported** from `models::aivcs` rather than re-defined so callers using `models::*` get a coherent surface and there is one canonical risk taxonomy.
- `src/models/mod.rs` — wires `pub mod aivcs;` and re-exports `ChangeSet`, `ChangeSetStatus`, `CreateChangeSet`.
- `src/db.rs`:
  - `pub const SQL_INSERT_CHANGE_SET` — binds `tenant_id` as `?1`, lists it as the first column.
  - `pub const SQL_GET_CHANGE_SET` — `WHERE tenant_id = ?1 AND id = ?2`.
  - `pub const SQL_LIST_CHANGE_SETS_BY_REPO` — `WHERE tenant_id = ?1 AND repo = ?2 ORDER BY created_at DESC LIMIT ?3`.
  - `pub async fn create_change_set` / `get_change_set` / `list_change_sets_by_repo` helpers wrapping the constants, plus the `ChangeSetRow` D1 deserializer and `into_change_set` adapter.

## Cross-tenant safety

All three SQL constants bind `tenant_id` as the leading parameter. Three new tests in `db::tests` pin the shape so a future edit that drops `tenant_id` from a WHERE clause or column list fails at PR-review time rather than as a cross-tenant data leak in prod:

- `cross_tenant_sql_insert_change_set_writes_tenant_id_at_position_1`
- `cross_tenant_sql_get_change_set_filters_on_tenant_id_first`
- `cross_tenant_sql_list_change_sets_by_repo_filters_on_tenant_id_first`

## Verification outcomes

All three required commands run from the repo root and pass clean:

```text
RUSTFLAGS="-D warnings" cargo check --target wasm32-unknown-unknown -p data-fabric-worker
  -> Finished `dev` profile, no warnings.

RUSTFLAGS="-D warnings --cfg=coverage" cargo check --tests -p data-fabric-worker
  -> Finished `dev` profile, no warnings.

cargo test -p data-fabric-worker --lib
  -> 401 passed; 0 failed; 0 ignored.
```

The 10 new tests (6 in `models::aivcs::tests`, 4 in `db::tests`) all pass:

```text
models::aivcs::tests::change_set_status_round_trips_str_to_enum_to_str_for_all_variants
models::aivcs::tests::change_set_status_default_storage_string_is_proposed
models::aivcs::tests::change_set_status_rejects_unknown_storage_value
models::aivcs::tests::change_set_round_trips_serde_json
models::aivcs::tests::change_set_round_trips_with_all_optional_fields_omitted
models::aivcs::tests::create_change_set_accepts_minimal_payload
db::tests::cross_tenant_sql_insert_change_set_writes_tenant_id_at_position_1
db::tests::cross_tenant_sql_get_change_set_filters_on_tenant_id_first
db::tests::cross_tenant_sql_list_change_sets_by_repo_filters_on_tenant_id_first
db::tests::change_set_risk_level_round_trips_through_storage_str
```

## Scope — what is NOT in this slice

- **No HTTP routes** (`POST /v1/aivcs/change-sets`, `GET /v1/aivcs/change-sets/:id`, etc.) — Slice 2.
- **No Gold read-models** (`gold_aivcs_review_queue`, `gold_aivcs_pr_workspace`, ...) — Slice 2.
- **No human-decision / review-thread projections** (`human_decision`, `review_thread`, `review_comment`, ...) — Slice 3.
- **No pause/resume run commands** (`POST /v1/runs/:id/pause` etc.) — Slice 4.
- **No SSE / Durable Object live updates / branch graph** — Slice 5.
- **No AIVCS-event-taxonomy ingest changes** — event types stay free-form on `/v1/events`; the `aivcs.change_set.proposed` / `agent.intent.recorded` / `human.guidance.added` taxonomy lands alongside the UI work.
- **No backfill of `Run.metadata.aivcs.change_set` rows** into the new table.

## Constraints checklist

- [x] DRAFT.
- [x] Slice strictly scoped — projection + types + DB layer only; zero HTTP wiring.
- [x] No secrets in any file or commit.
- [x] Migration is idempotent (`IF NOT EXISTS` on table + all three indexes).
- [x] All three SQL constants bind `tenant_id` as the leading parameter and have a test that pins this.
- [x] Remote push verified — `git ls-remote origin feat/aivcs-slice-1-change-set` resolved to the commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)