### PR TITLE
feat(aivcs): add review_thread + comment + resolution + file_anchor projections

### DIFF
--- a/migrations/0016_aivcs_review_projections.sql
+++ b/migrations/0016_aivcs_review_projections.sql
@@ -1,0 +1,85 @@
+-- AIVCS review-projection tables (issue #148, wave-1 slice 2).
+--
+-- Provenance events alone (e.g. `aivcs.review.opened`, `human.review.comment_added`)
+-- are sufficient for audit but not for the AIVCS UI: rendering a review pane
+-- needs durable comment threads, resolved state, and inline file anchors that
+-- can be paginated and updated independently of the event log.
+--
+-- These projection tables are written from the event taxonomy (slice 1) by a
+-- follower process — they intentionally carry no business logic of their own,
+-- only shape. CRUD helpers and HTTP routes are added in later slices.
+--
+-- Multi-tenancy: every table carries `tenant_id TEXT NOT NULL DEFAULT ''` as
+-- the leading PRIMARY KEY component, matching the convention introduced in
+-- migrations 0005 and 0014. The empty-string default marks pre-existing /
+-- unattributed rows (there are none on first deploy, but the column shape
+-- is consistent with the rest of the schema so backfills work).
+--
+-- Idempotency: every CREATE uses IF NOT EXISTS so the migration can be safely
+-- re-applied during dev resets and CI replays.
+
+-- ── review_thread ────────────────────────────────────────────────
+-- One thread per review conversation. `change_set_id` is nullable because
+-- the first wave of AIVCS reviews may be attached to a Run only (the
+-- change_set entity is itself a later projection — see issue #148 §5).
+CREATE TABLE IF NOT EXISTS review_thread (
+    tenant_id TEXT NOT NULL DEFAULT '',
+    id TEXT NOT NULL,
+    review_id TEXT NOT NULL,
+    change_set_id TEXT,
+    status TEXT NOT NULL DEFAULT 'open',     -- open | resolved
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    resolved_at TEXT,
+    PRIMARY KEY (tenant_id, id)
+);
+CREATE INDEX IF NOT EXISTS idx_review_thread_tenant_review
+    ON review_thread(tenant_id, review_id);
+
+-- ── review_comment ───────────────────────────────────────────────
+-- One row per comment in a thread. `actor` follows the AIVCS event taxonomy:
+-- 'human:<id>' or 'agent:<id>'. `parent_comment_id` enables reply chains
+-- without a separate adjacency table.
+CREATE TABLE IF NOT EXISTS review_comment (
+    tenant_id TEXT NOT NULL DEFAULT '',
+    id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    actor TEXT NOT NULL,                     -- 'human:<id>' or 'agent:<id>'
+    body TEXT NOT NULL,
+    parent_comment_id TEXT,                  -- for reply chains
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (tenant_id, id)
+);
+CREATE INDEX IF NOT EXISTS idx_review_comment_tenant_thread
+    ON review_comment(tenant_id, thread_id, created_at);
+
+-- ── review_thread_resolution ─────────────────────────────────────
+-- Optional one-row-per-thread resolution record. Kept in a separate table
+-- (rather than denormalised onto review_thread) so the resolution metadata
+-- — actor, free-form note, taxonomy — has a stable identity for audit and
+-- future relationship edges (causality).
+CREATE TABLE IF NOT EXISTS review_thread_resolution (
+    tenant_id TEXT NOT NULL DEFAULT '',
+    thread_id TEXT NOT NULL,
+    resolved_by TEXT NOT NULL,
+    resolution TEXT NOT NULL,                -- 'fixed' | 'wont_fix' | 'duplicate' | 'discussion'
+    note TEXT,
+    resolved_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (tenant_id, thread_id)
+);
+
+-- ── file_anchor ──────────────────────────────────────────────────
+-- An inline anchor pins a thread to a line range in a file on a specific
+-- side of a diff. A thread can have zero or more anchors (e.g. a global
+-- comment has none; a multi-file thread has many).
+CREATE TABLE IF NOT EXISTS file_anchor (
+    tenant_id TEXT NOT NULL DEFAULT '',
+    id TEXT NOT NULL,
+    thread_id TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    side TEXT NOT NULL DEFAULT 'right',      -- 'left' (base) | 'right' (head)
+    PRIMARY KEY (tenant_id, id)
+);
+CREATE INDEX IF NOT EXISTS idx_file_anchor_tenant_thread
+    ON file_anchor(tenant_id, thread_id);

--- a/src/db.rs
+++ b/src/db.rs
@@ -60,6 +60,70 @@ pub const SQL_LIST_CHANGE_SETS_BY_REPO: &str =
      ORDER BY created_at DESC \
      LIMIT ?3";
 
+// ── AIVCS review projections (issue #148 slice 2) ──────────────
+//
+// All four projection tables introduced in migration 0016 carry
+// `tenant_id` as the leading PRIMARY KEY component. The SQL
+// statements below MUST bind `tenant_id` as ?1 on every read and
+// every write; the cross-tenant tests at the bottom of this file
+// assert that shape.
+//
+// The constants and CRUD helpers below are not yet referenced from
+// `lib.rs` — slice 2 is projection-only. They are exercised by the
+// cross-tenant SQL-shape tests at the bottom of this file and will
+// be consumed by the slice-3+ HTTP routes and the projection
+// follower. `#[allow(dead_code)]` keeps the wasm `-D warnings`
+// build green until those slices land.
+
+#[allow(dead_code)]
+const SQL_INSERT_REVIEW_THREAD: &str =
+    "INSERT INTO review_thread (tenant_id, id, review_id, change_set_id, status, created_at, resolved_at)\n     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
+
+#[allow(dead_code)]
+const SQL_GET_REVIEW_THREAD: &str =
+    "SELECT id, review_id, change_set_id, status, created_at, resolved_at \
+     FROM review_thread WHERE tenant_id = ?1 AND id = ?2";
+
+#[allow(dead_code)]
+const SQL_LIST_REVIEW_THREADS_FOR_REVIEW: &str =
+    "SELECT id, review_id, change_set_id, status, created_at, resolved_at \
+     FROM review_thread WHERE tenant_id = ?1 AND review_id = ?2 \
+     ORDER BY created_at ASC LIMIT ?3";
+
+#[allow(dead_code)]
+const SQL_UPDATE_REVIEW_THREAD_STATUS: &str =
+    "UPDATE review_thread SET status = ?3, resolved_at = ?4 \
+     WHERE tenant_id = ?1 AND id = ?2";
+
+#[allow(dead_code)]
+const SQL_INSERT_REVIEW_COMMENT: &str =
+    "INSERT INTO review_comment (tenant_id, id, thread_id, actor, body, parent_comment_id, created_at)\n     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
+
+#[allow(dead_code)]
+const SQL_LIST_REVIEW_COMMENTS_FOR_THREAD: &str =
+    "SELECT id, thread_id, actor, body, parent_comment_id, created_at \
+     FROM review_comment WHERE tenant_id = ?1 AND thread_id = ?2 \
+     ORDER BY created_at ASC, id ASC LIMIT ?3";
+
+#[allow(dead_code)]
+const SQL_INSERT_REVIEW_THREAD_RESOLUTION: &str =
+    "INSERT INTO review_thread_resolution (tenant_id, thread_id, resolved_by, resolution, note, resolved_at)\n     VALUES (?1, ?2, ?3, ?4, ?5, ?6)";
+
+#[allow(dead_code)]
+const SQL_GET_REVIEW_THREAD_RESOLUTION: &str =
+    "SELECT thread_id, resolved_by, resolution, note, resolved_at \
+     FROM review_thread_resolution WHERE tenant_id = ?1 AND thread_id = ?2";
+
+#[allow(dead_code)]
+const SQL_INSERT_FILE_ANCHOR: &str =
+    "INSERT INTO file_anchor (tenant_id, id, thread_id, file_path, start_line, end_line, side)\n     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
+
+#[allow(dead_code)]
+const SQL_LIST_FILE_ANCHORS_FOR_THREAD: &str =
+    "SELECT id, thread_id, file_path, start_line, end_line, side \
+     FROM file_anchor WHERE tenant_id = ?1 AND thread_id = ?2 \
+     ORDER BY file_path ASC, start_line ASC, id ASC LIMIT ?3";
+
 pub fn now_iso() -> String {
     js_sys::Date::new_0().to_iso_string().as_string().unwrap()
 }
@@ -2624,6 +2688,212 @@ fn days_ago_expr(days: i64) -> String {
     format!("-{} days", days.max(1))
 }
 
+// ── AIVCS review projections (issue #148 slice 2) ──────────────
+//
+// CRUD helpers for the four review-projection tables introduced by
+// migration 0016. Every helper takes `tenant_id` as the leading
+// argument and binds it as ?1; the SQL constants used here are
+// asserted to keep that shape by the `cross_tenant_sql_aivcs_*` tests.
+//
+// No HTTP routes are wired in this slice; the helpers exist so the
+// follower process and (later) BFF can write/read the projection
+// without re-typing SQL.
+
+#[allow(dead_code)]
+pub async fn insert_review_thread(
+    db: &D1Database,
+    tenant_id: &str,
+    thread: &models::aivcs_review::ReviewThread,
+) -> Result<()> {
+    db.prepare(SQL_INSERT_REVIEW_THREAD)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(&thread.id),
+            JsValue::from_str(&thread.review_id),
+            opt_str(&thread.change_set_id),
+            JsValue::from_str(thread.status.as_sql()),
+            JsValue::from_str(&thread.created_at),
+            opt_str(&thread.resolved_at),
+        ])?
+        .run()
+        .await?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn get_review_thread(
+    db: &D1Database,
+    tenant_id: &str,
+    id: &str,
+) -> Result<Option<models::aivcs_review::ReviewThread>> {
+    let row: Option<ReviewThreadRow> = db
+        .prepare(SQL_GET_REVIEW_THREAD)
+        .bind(&[JsValue::from_str(tenant_id), JsValue::from_str(id)])?
+        .first(None)
+        .await?;
+    Ok(row.and_then(|r| r.into_review_thread()))
+}
+
+#[allow(dead_code)]
+pub async fn list_review_threads_for_review(
+    db: &D1Database,
+    tenant_id: &str,
+    review_id: &str,
+    limit: u32,
+) -> Result<Vec<models::aivcs_review::ReviewThread>> {
+    let result: D1Result = db
+        .prepare(SQL_LIST_REVIEW_THREADS_FOR_REVIEW)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(review_id),
+            JsValue::from(limit),
+        ])?
+        .all()
+        .await?;
+    let rows: Vec<ReviewThreadRow> = result.results()?;
+    Ok(rows.into_iter().filter_map(|r| r.into_review_thread()).collect())
+}
+
+#[allow(dead_code)]
+pub async fn update_review_thread_status(
+    db: &D1Database,
+    tenant_id: &str,
+    id: &str,
+    status: models::aivcs_review::ReviewThreadStatus,
+    resolved_at: Option<&str>,
+) -> Result<()> {
+    let resolved_at_js = match resolved_at {
+        Some(s) => JsValue::from_str(s),
+        None => JsValue::NULL,
+    };
+    db.prepare(SQL_UPDATE_REVIEW_THREAD_STATUS)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(id),
+            JsValue::from_str(status.as_sql()),
+            resolved_at_js,
+        ])?
+        .run()
+        .await?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn insert_review_comment(
+    db: &D1Database,
+    tenant_id: &str,
+    comment: &models::aivcs_review::ReviewComment,
+) -> Result<()> {
+    db.prepare(SQL_INSERT_REVIEW_COMMENT)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(&comment.id),
+            JsValue::from_str(&comment.thread_id),
+            JsValue::from_str(&comment.actor.to_sql_actor()),
+            JsValue::from_str(&comment.body),
+            opt_str(&comment.parent_comment_id),
+            JsValue::from_str(&comment.created_at),
+        ])?
+        .run()
+        .await?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn list_review_comments_for_thread(
+    db: &D1Database,
+    tenant_id: &str,
+    thread_id: &str,
+    limit: u32,
+) -> Result<Vec<models::aivcs_review::ReviewComment>> {
+    let result: D1Result = db
+        .prepare(SQL_LIST_REVIEW_COMMENTS_FOR_THREAD)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(thread_id),
+            JsValue::from(limit),
+        ])?
+        .all()
+        .await?;
+    let rows: Vec<ReviewCommentRow> = result.results()?;
+    Ok(rows.into_iter().filter_map(|r| r.into_review_comment()).collect())
+}
+
+#[allow(dead_code)]
+pub async fn insert_review_thread_resolution(
+    db: &D1Database,
+    tenant_id: &str,
+    resolution: &models::aivcs_review::ReviewThreadResolution,
+) -> Result<()> {
+    db.prepare(SQL_INSERT_REVIEW_THREAD_RESOLUTION)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(&resolution.thread_id),
+            JsValue::from_str(&resolution.resolved_by),
+            JsValue::from_str(resolution.resolution.as_sql()),
+            opt_str(&resolution.note),
+            JsValue::from_str(&resolution.resolved_at),
+        ])?
+        .run()
+        .await?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn get_review_thread_resolution(
+    db: &D1Database,
+    tenant_id: &str,
+    thread_id: &str,
+) -> Result<Option<models::aivcs_review::ReviewThreadResolution>> {
+    let row: Option<ReviewThreadResolutionRow> = db
+        .prepare(SQL_GET_REVIEW_THREAD_RESOLUTION)
+        .bind(&[JsValue::from_str(tenant_id), JsValue::from_str(thread_id)])?
+        .first(None)
+        .await?;
+    Ok(row.and_then(|r| r.into_resolution()))
+}
+
+#[allow(dead_code)]
+pub async fn insert_file_anchor(
+    db: &D1Database,
+    tenant_id: &str,
+    anchor: &models::aivcs_review::FileAnchor,
+) -> Result<()> {
+    db.prepare(SQL_INSERT_FILE_ANCHOR)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(&anchor.id),
+            JsValue::from_str(&anchor.thread_id),
+            JsValue::from_str(&anchor.file_path),
+            JsValue::from_f64(anchor.start_line() as f64),
+            JsValue::from_f64(anchor.end_line() as f64),
+            JsValue::from_str(anchor.side.as_sql()),
+        ])?
+        .run()
+        .await?;
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn list_file_anchors_for_thread(
+    db: &D1Database,
+    tenant_id: &str,
+    thread_id: &str,
+    limit: u32,
+) -> Result<Vec<models::aivcs_review::FileAnchor>> {
+    let result: D1Result = db
+        .prepare(SQL_LIST_FILE_ANCHORS_FOR_THREAD)
+        .bind(&[
+            JsValue::from_str(tenant_id),
+            JsValue::from_str(thread_id),
+            JsValue::from(limit),
+        ])?
+        .all()
+        .await?;
+    let rows: Vec<FileAnchorRow> = result.results()?;
+    Ok(rows.into_iter().filter_map(|r| r.into_file_anchor()).collect())
+}
+
 // ── Internal row types ──────────────────────────────────────────
 
 #[allow(dead_code)]
@@ -2926,6 +3196,111 @@ pub struct Ws2TaskResponse {
     pub created_at: String,
     pub updated_at: String,
     pub metadata: Option<serde_json::Value>,
+}
+
+// ── AIVCS review-projection row types (issue #148 slice 2) ─────
+
+#[allow(dead_code)]
+#[derive(Debug, serde::Deserialize)]
+struct ReviewThreadRow {
+    id: String,
+    review_id: String,
+    change_set_id: Option<String>,
+    status: String,
+    created_at: String,
+    resolved_at: Option<String>,
+}
+
+#[allow(dead_code)]
+impl ReviewThreadRow {
+    fn into_review_thread(self) -> Option<models::aivcs_review::ReviewThread> {
+        let status = models::aivcs_review::ReviewThreadStatus::from_sql(&self.status)?;
+        Some(models::aivcs_review::ReviewThread {
+            id: self.id,
+            review_id: self.review_id,
+            change_set_id: self.change_set_id,
+            status,
+            created_at: self.created_at,
+            resolved_at: self.resolved_at,
+        })
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, serde::Deserialize)]
+struct ReviewCommentRow {
+    id: String,
+    thread_id: String,
+    actor: String,
+    body: String,
+    parent_comment_id: Option<String>,
+    created_at: String,
+}
+
+#[allow(dead_code)]
+impl ReviewCommentRow {
+    fn into_review_comment(self) -> Option<models::aivcs_review::ReviewComment> {
+        let actor = models::aivcs_review::CommentActor::from_sql_actor(&self.actor)?;
+        Some(models::aivcs_review::ReviewComment {
+            id: self.id,
+            thread_id: self.thread_id,
+            actor,
+            body: self.body,
+            parent_comment_id: self.parent_comment_id,
+            created_at: self.created_at,
+        })
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, serde::Deserialize)]
+struct ReviewThreadResolutionRow {
+    thread_id: String,
+    resolved_by: String,
+    resolution: String,
+    note: Option<String>,
+    resolved_at: String,
+}
+
+#[allow(dead_code)]
+impl ReviewThreadResolutionRow {
+    fn into_resolution(self) -> Option<models::aivcs_review::ReviewThreadResolution> {
+        let resolution = models::aivcs_review::Resolution::from_sql(&self.resolution)?;
+        Some(models::aivcs_review::ReviewThreadResolution {
+            thread_id: self.thread_id,
+            resolved_by: self.resolved_by,
+            resolution,
+            note: self.note,
+            resolved_at: self.resolved_at,
+        })
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, serde::Deserialize)]
+struct FileAnchorRow {
+    id: String,
+    thread_id: String,
+    file_path: String,
+    start_line: i64,
+    end_line: i64,
+    side: String,
+}
+
+#[allow(dead_code)]
+impl FileAnchorRow {
+    fn into_file_anchor(self) -> Option<models::aivcs_review::FileAnchor> {
+        let side = models::aivcs_review::AnchorSide::from_sql(&self.side)?;
+        models::aivcs_review::FileAnchor::from_row(
+            self.id,
+            self.thread_id,
+            self.file_path,
+            self.start_line,
+            self.end_line,
+            side,
+        )
+        .ok()
+    }
 }
 
 // ── Provenance Links (WS3: causality chain) ─────────────────────
@@ -4346,5 +4721,87 @@ mod tests {
         // on (created_at, id).
         assert_eq!(cursor.priority, 100);
         assert_eq!(cursor.id, "r2");
+    }
+
+    // ── Cross-tenant SQL shape: AIVCS review projections (#148) ─
+
+    /// Every read against the AIVCS review-projection tables must
+    /// filter by `tenant_id = ?1`. Without this, threads, comments,
+    /// resolutions, or file anchors written under tenant A would be
+    /// visible to tenant B — a cross-tenant data leak through what
+    /// looks like a benign read model.
+    #[test]
+    fn cross_tenant_sql_aivcs_review_thread_select_filters_on_tenant_id() {
+        for (label, sql) in [
+            ("SQL_GET_REVIEW_THREAD", SQL_GET_REVIEW_THREAD),
+            (
+                "SQL_LIST_REVIEW_THREADS_FOR_REVIEW",
+                SQL_LIST_REVIEW_THREADS_FOR_REVIEW,
+            ),
+            (
+                "SQL_LIST_REVIEW_COMMENTS_FOR_THREAD",
+                SQL_LIST_REVIEW_COMMENTS_FOR_THREAD,
+            ),
+            (
+                "SQL_GET_REVIEW_THREAD_RESOLUTION",
+                SQL_GET_REVIEW_THREAD_RESOLUTION,
+            ),
+            (
+                "SQL_LIST_FILE_ANCHORS_FOR_THREAD",
+                SQL_LIST_FILE_ANCHORS_FOR_THREAD,
+            ),
+        ] {
+            assert!(
+                sql.contains("WHERE tenant_id = ?1"),
+                "{label} must filter by tenant_id as ?1; got: {sql}",
+            );
+        }
+    }
+
+    /// Every write into the AIVCS review-projection tables must bind
+    /// `tenant_id` as the leading column (so it lands as ?1) — this
+    /// matches the convention used by every other multi-tenant table
+    /// in the schema.
+    #[test]
+    fn cross_tenant_sql_aivcs_review_inserts_lead_with_tenant_id() {
+        for (table_name, sql) in [
+            ("review_thread", SQL_INSERT_REVIEW_THREAD),
+            ("review_comment", SQL_INSERT_REVIEW_COMMENT),
+            (
+                "review_thread_resolution",
+                SQL_INSERT_REVIEW_THREAD_RESOLUTION,
+            ),
+            ("file_anchor", SQL_INSERT_FILE_ANCHOR),
+        ] {
+            let needle = format!("{table_name} (");
+            let start = sql
+                .find(&needle)
+                .unwrap_or_else(|| panic!("expected INSERT into {table_name}; got: {sql}"));
+            let tail = &sql[start..];
+            assert!(
+                tail.starts_with(&format!("{table_name} (tenant_id,")),
+                "tenant_id must be the first column of the INSERT list for {table_name}; got: {tail}",
+            );
+            assert!(
+                sql.contains("(?1, ?2"),
+                "INSERT for {table_name} must bind tenant_id as ?1; got: {sql}",
+            );
+        }
+    }
+
+    /// The UPDATE for review-thread status must also be tenant-scoped
+    /// — otherwise tenant A could mark tenant B's thread resolved.
+    #[test]
+    fn cross_tenant_sql_aivcs_review_thread_update_scopes_to_tenant() {
+        assert!(
+            SQL_UPDATE_REVIEW_THREAD_STATUS.contains("WHERE tenant_id = ?1 AND id = ?2"),
+            "review_thread status update must filter by tenant_id and id; got: {}",
+            SQL_UPDATE_REVIEW_THREAD_STATUS,
+        );
+        assert!(
+            SQL_UPDATE_REVIEW_THREAD_STATUS.contains("UPDATE review_thread"),
+            "review_thread status update must target review_thread; got: {}",
+            SQL_UPDATE_REVIEW_THREAD_STATUS,
+        );
     }
 }

--- a/src/models/aivcs_review.rs
+++ b/src/models/aivcs_review.rs
@@ -1,0 +1,458 @@
+//! AIVCS review projections (issue #148, wave-1 slice 2).
+//!
+//! These types mirror the SQL projection tables introduced in
+//! `migrations/0016_aivcs_review_projections.sql`. They are
+//! intentionally separate from the (forthcoming) slice-1
+//! `models::aivcs` module: that module owns the AIVCS *event
+//! taxonomy*; this one owns the *read-model shape* the UI consumes.
+//!
+//! Provenance lives in events. Projections live here.
+//!
+//! No HTTP routes are exposed in this slice — the types are reachable
+//! from `db.rs` CRUD helpers only.
+
+use serde::{Deserialize, Serialize};
+
+// ── Enums ───────────────────────────────────────────────────────
+
+/// Lifecycle status of a single review thread.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewThreadStatus {
+    /// Newly created or re-opened thread; not yet resolved.
+    Open,
+    /// Thread has been resolved (see [`ReviewThreadResolution`]).
+    Resolved,
+}
+
+impl ReviewThreadStatus {
+    /// SQL-encoded representation matching the `status` column of `review_thread`.
+    pub fn as_sql(&self) -> &'static str {
+        match self {
+            ReviewThreadStatus::Open => "open",
+            ReviewThreadStatus::Resolved => "resolved",
+        }
+    }
+
+    /// Parse the on-disk SQL form back to a [`ReviewThreadStatus`].
+    pub fn from_sql(s: &str) -> Option<Self> {
+        match s {
+            "open" => Some(ReviewThreadStatus::Open),
+            "resolved" => Some(ReviewThreadStatus::Resolved),
+            _ => None,
+        }
+    }
+}
+
+/// Comment actor — either a human user or an AI agent. The `id` is
+/// the AIVCS-side identifier (e.g. `jane.taylor` for humans,
+/// `optimizer-7` for agents) — matching the event-taxonomy actor
+/// shape (`human:<id>` / `agent:<id>`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
+pub enum CommentActor {
+    Human(String),
+    Agent(String),
+}
+
+impl CommentActor {
+    /// Render in the on-disk shape used by the `review_comment.actor` column.
+    pub fn to_sql_actor(&self) -> String {
+        match self {
+            CommentActor::Human(id) => format!("human:{id}"),
+            CommentActor::Agent(id) => format!("agent:{id}"),
+        }
+    }
+
+    /// Parse the on-disk `human:<id>` / `agent:<id>` form.
+    ///
+    /// Returns `None` for any other prefix, an empty id, or an unknown kind.
+    pub fn from_sql_actor(s: &str) -> Option<Self> {
+        let (kind, id) = s.split_once(':')?;
+        if id.is_empty() {
+            return None;
+        }
+        match kind {
+            "human" => Some(CommentActor::Human(id.to_owned())),
+            "agent" => Some(CommentActor::Agent(id.to_owned())),
+            _ => None,
+        }
+    }
+}
+
+/// Why a review thread was closed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Resolution {
+    /// The reported issue was addressed in code.
+    Fixed,
+    /// The reported issue was acknowledged but will not be acted on.
+    WontFix,
+    /// The thread duplicates another open or resolved thread.
+    Duplicate,
+    /// The thread was a discussion that reached a conclusion without code change.
+    Discussion,
+}
+
+impl Resolution {
+    pub fn as_sql(&self) -> &'static str {
+        match self {
+            Resolution::Fixed => "fixed",
+            Resolution::WontFix => "wont_fix",
+            Resolution::Duplicate => "duplicate",
+            Resolution::Discussion => "discussion",
+        }
+    }
+
+    pub fn from_sql(s: &str) -> Option<Self> {
+        match s {
+            "fixed" => Some(Resolution::Fixed),
+            "wont_fix" => Some(Resolution::WontFix),
+            "duplicate" => Some(Resolution::Duplicate),
+            "discussion" => Some(Resolution::Discussion),
+            _ => None,
+        }
+    }
+}
+
+/// Side of a diff a file anchor pins to.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AnchorSide {
+    /// Base side of the diff.
+    Left,
+    /// Head side of the diff (default for new comments).
+    Right,
+}
+
+impl AnchorSide {
+    pub fn as_sql(&self) -> &'static str {
+        match self {
+            AnchorSide::Left => "left",
+            AnchorSide::Right => "right",
+        }
+    }
+
+    pub fn from_sql(s: &str) -> Option<Self> {
+        match s {
+            "left" => Some(AnchorSide::Left),
+            "right" => Some(AnchorSide::Right),
+            _ => None,
+        }
+    }
+}
+
+// ── Structs ─────────────────────────────────────────────────────
+
+/// One review conversation, attached to a review and (optionally) a change set.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewThread {
+    pub id: String,
+    pub review_id: String,
+    pub change_set_id: Option<String>,
+    pub status: ReviewThreadStatus,
+    pub created_at: String,
+    pub resolved_at: Option<String>,
+}
+
+/// One comment in a review thread.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewComment {
+    pub id: String,
+    pub thread_id: String,
+    pub actor: CommentActor,
+    pub body: String,
+    pub parent_comment_id: Option<String>,
+    pub created_at: String,
+}
+
+/// Resolution metadata for a review thread.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewThreadResolution {
+    pub thread_id: String,
+    pub resolved_by: String,
+    pub resolution: Resolution,
+    pub note: Option<String>,
+    pub resolved_at: String,
+}
+
+/// Error returned when an attempted [`FileAnchor`] has `end_line < start_line`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidLineRange {
+    pub start_line: i64,
+    pub end_line: i64,
+}
+
+impl std::fmt::Display for InvalidLineRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "file_anchor: end_line ({}) must be >= start_line ({})",
+            self.end_line, self.start_line
+        )
+    }
+}
+
+impl std::error::Error for InvalidLineRange {}
+
+/// Pins a thread to a file + line range on one side of the diff.
+///
+/// Construction goes through [`FileAnchor::new`], which rejects
+/// `end_line < start_line` at the type level. The struct fields are
+/// private so the only way to land an invalid anchor is via direct
+/// deserialisation from trusted projection storage (`from_row`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileAnchor {
+    pub id: String,
+    pub thread_id: String,
+    pub file_path: String,
+    start_line: i64,
+    end_line: i64,
+    pub side: AnchorSide,
+}
+
+impl FileAnchor {
+    /// Construct a new [`FileAnchor`], validating the line range.
+    pub fn new(
+        id: String,
+        thread_id: String,
+        file_path: String,
+        start_line: i64,
+        end_line: i64,
+        side: AnchorSide,
+    ) -> std::result::Result<Self, InvalidLineRange> {
+        if end_line < start_line {
+            return Err(InvalidLineRange {
+                start_line,
+                end_line,
+            });
+        }
+        Ok(Self {
+            id,
+            thread_id,
+            file_path,
+            start_line,
+            end_line,
+            side,
+        })
+    }
+
+    /// Re-hydrate an anchor from trusted projection storage. The
+    /// migration enforces NOT NULL on `start_line` / `end_line`, but
+    /// not the ordering — we still validate here so an external
+    /// writer cannot smuggle in `end_line < start_line`.
+    pub fn from_row(
+        id: String,
+        thread_id: String,
+        file_path: String,
+        start_line: i64,
+        end_line: i64,
+        side: AnchorSide,
+    ) -> std::result::Result<Self, InvalidLineRange> {
+        Self::new(id, thread_id, file_path, start_line, end_line, side)
+    }
+
+    pub fn start_line(&self) -> i64 {
+        self.start_line
+    }
+
+    pub fn end_line(&self) -> i64 {
+        self.end_line
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Enum SQL round-trips ────────────────────────────────────
+
+    #[test]
+    fn review_thread_status_sql_round_trip() {
+        for s in [ReviewThreadStatus::Open, ReviewThreadStatus::Resolved] {
+            let sql = s.as_sql();
+            let parsed = ReviewThreadStatus::from_sql(sql).expect("known status");
+            assert_eq!(parsed, s);
+        }
+        assert!(ReviewThreadStatus::from_sql("bogus").is_none());
+    }
+
+    #[test]
+    fn review_thread_status_serde_round_trip() {
+        // Both variants must JSON-round-trip in snake_case, since the
+        // BFF will read this shape directly off the wire.
+        for (s, expected) in [
+            (ReviewThreadStatus::Open, "\"open\""),
+            (ReviewThreadStatus::Resolved, "\"resolved\""),
+        ] {
+            let json = serde_json::to_string(&s).unwrap();
+            assert_eq!(json, expected);
+            let parsed: ReviewThreadStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, s);
+        }
+    }
+
+    #[test]
+    fn resolution_sql_round_trip() {
+        for r in [
+            Resolution::Fixed,
+            Resolution::WontFix,
+            Resolution::Duplicate,
+            Resolution::Discussion,
+        ] {
+            assert_eq!(Resolution::from_sql(r.as_sql()), Some(r));
+        }
+        assert!(Resolution::from_sql("retired").is_none());
+    }
+
+    #[test]
+    fn anchor_side_sql_round_trip() {
+        for s in [AnchorSide::Left, AnchorSide::Right] {
+            assert_eq!(AnchorSide::from_sql(s.as_sql()), Some(s));
+        }
+        assert!(AnchorSide::from_sql("center").is_none());
+    }
+
+    // ── CommentActor parsing ────────────────────────────────────
+
+    #[test]
+    fn comment_actor_parses_human_jane() {
+        let parsed = CommentActor::from_sql_actor("human:jane").expect("parses");
+        assert_eq!(parsed, CommentActor::Human("jane".into()));
+        // Round-trips through the SQL representation.
+        assert_eq!(parsed.to_sql_actor(), "human:jane");
+    }
+
+    #[test]
+    fn comment_actor_parses_agent_optimizer_7() {
+        let parsed = CommentActor::from_sql_actor("agent:optimizer-7").expect("parses");
+        assert_eq!(parsed, CommentActor::Agent("optimizer-7".into()));
+        assert_eq!(parsed.to_sql_actor(), "agent:optimizer-7");
+    }
+
+    #[test]
+    fn comment_actor_rejects_malformed_strings() {
+        // No colon -> no split possible.
+        assert!(CommentActor::from_sql_actor("janedoe").is_none());
+        // Unknown kind.
+        assert!(CommentActor::from_sql_actor("bot:1").is_none());
+        // Empty id.
+        assert!(CommentActor::from_sql_actor("human:").is_none());
+    }
+
+    #[test]
+    fn comment_actor_id_may_contain_colons() {
+        // Tenant-qualified agent ids ("agent:tenant-a:optimizer-7") must
+        // survive the split — split_once keeps the tail intact.
+        let parsed = CommentActor::from_sql_actor("agent:tenant-a:optimizer-7").expect("parses");
+        assert_eq!(parsed, CommentActor::Agent("tenant-a:optimizer-7".into()));
+    }
+
+    // ── FileAnchor invariants ───────────────────────────────────
+
+    #[test]
+    fn file_anchor_accepts_valid_line_ranges() {
+        // Single-line anchor.
+        let single = FileAnchor::new(
+            "fa1".into(),
+            "th1".into(),
+            "src/lib.rs".into(),
+            10,
+            10,
+            AnchorSide::Right,
+        )
+        .expect("single-line accepted");
+        assert_eq!(single.start_line(), 10);
+        assert_eq!(single.end_line(), 10);
+
+        // Multi-line anchor.
+        let multi = FileAnchor::new(
+            "fa2".into(),
+            "th1".into(),
+            "src/lib.rs".into(),
+            10,
+            42,
+            AnchorSide::Left,
+        )
+        .expect("multi-line accepted");
+        assert_eq!(multi.start_line(), 10);
+        assert_eq!(multi.end_line(), 42);
+        assert_eq!(multi.side, AnchorSide::Left);
+    }
+
+    #[test]
+    fn file_anchor_rejects_inverted_line_ranges() {
+        let err = FileAnchor::new(
+            "fa3".into(),
+            "th1".into(),
+            "src/lib.rs".into(),
+            42,
+            10,
+            AnchorSide::Right,
+        )
+        .expect_err("must reject end_line < start_line");
+        assert_eq!(err.start_line, 42);
+        assert_eq!(err.end_line, 10);
+    }
+
+    #[test]
+    fn file_anchor_from_row_validates_too() {
+        // Even from "trusted" storage we re-validate, so a malicious
+        // direct INSERT cannot smuggle in an inverted range.
+        assert!(FileAnchor::from_row(
+            "fa4".into(),
+            "th1".into(),
+            "src/lib.rs".into(),
+            100,
+            50,
+            AnchorSide::Right,
+        )
+        .is_err());
+    }
+
+    // ── Struct serde round-trips ────────────────────────────────
+
+    #[test]
+    fn review_thread_round_trip() {
+        let t = ReviewThread {
+            id: "th1".into(),
+            review_id: "rev1".into(),
+            change_set_id: Some("chg1".into()),
+            status: ReviewThreadStatus::Open,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            resolved_at: None,
+        };
+        let json = serde_json::to_string(&t).unwrap();
+        let parsed: ReviewThread = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, t);
+    }
+
+    #[test]
+    fn review_comment_round_trip() {
+        let c = ReviewComment {
+            id: "c1".into(),
+            thread_id: "th1".into(),
+            actor: CommentActor::Human("jane".into()),
+            body: "looks good".into(),
+            parent_comment_id: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        let parsed: ReviewComment = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, c);
+    }
+
+    #[test]
+    fn review_thread_resolution_round_trip() {
+        let r = ReviewThreadResolution {
+            thread_id: "th1".into(),
+            resolved_by: "human:jane".into(),
+            resolution: Resolution::Fixed,
+            note: Some("addressed in chg2".into()),
+            resolved_at: "2026-01-02T00:00:00Z".into(),
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let parsed: ReviewThreadResolution = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, r);
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -25,6 +25,14 @@ mod memory;
 // AIVCS — slice 1: native `change_set` projection (issue #148).
 pub mod aivcs;
 
+// AIVCS review projections (issue #148 slice 2).
+// Read by the slice-3+ HTTP routes (not yet landed) and by the
+// follower process that projects events onto these tables, so
+// the public API is intentionally broader than what's referenced
+// from lib.rs in this slice.
+#[allow(dead_code)]
+pub mod aivcs_review;
+
 pub use entities::*;
 pub use memory::*;
 pub use orchestration::*;
@@ -32,6 +40,8 @@ pub use orchestration::*;
 pub use relationships::*;
 pub use requests::*;
 pub use aivcs::{ChangeSet, ChangeSetStatus, CreateChangeSet};
+#[allow(unused_imports)]
+pub use aivcs_review::*;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Slice 2 of issue #148 — AIVCS review projections

**Refs #148** (partial — not closes; the issue stays open until all 6 wave-1 slices land).

Draft — opened for review.

## Why

Per issue #148 §4 ("Review/comment projection"):

> Events are enough for audit, but the UI needs comment threads, resolved state, and inline file anchors. Add projection tables for: `review_thread`, `review_comment`, `review_thread_resolution`, `file_anchor`.

The AIVCS event taxonomy (slice 1) is sufficient for provenance and replay. It is **not** sufficient for the UI — rendering a review pane needs durable, paginable, mutable read models for comment threads. This slice lands the storage shape and the Rust types the views will consume. The projection follower and HTTP routes ship in later slices.

## What landed

### Migration — `migrations/0016_aivcs_review_projections.sql`

Idempotent `CREATE TABLE IF NOT EXISTS` for four projection tables:

| Table                       | Purpose                                                       |
| --------------------------- | ------------------------------------------------------------- |
| `review_thread`             | One thread per review conversation (`open` / `resolved`).     |
| `review_comment`            | Comments in a thread, with `human:<id>` / `agent:<id>` actor and reply chains. |
| `review_thread_resolution`  | Resolution metadata (`fixed` / `wont_fix` / `duplicate` / `discussion`). |
| `file_anchor`               | Inline file + line-range anchors on either side of a diff.    |

Every table carries `tenant_id TEXT NOT NULL DEFAULT ''` as the leading PRIMARY KEY component, matching the convention in migrations 0005 / 0014. Lookup indexes are tenant-scoped (`idx_review_thread_tenant_review`, `idx_review_comment_tenant_thread`, `idx_file_anchor_tenant_thread`).

### Rust types — `src/models/aivcs_review.rs` (NEW)

Separate from slice 1's `aivcs.rs` (which owns the event taxonomy). This module owns the read-model shape:

- Structs: `ReviewThread`, `ReviewComment`, `ReviewThreadResolution`, `FileAnchor`.
- Enums: `ReviewThreadStatus` (`Open` / `Resolved`), `CommentActor` (`Human(id)` / `Agent(id)`), `Resolution` (`Fixed` / `WontFix` / `Duplicate` / `Discussion`), `AnchorSide` (`Left` / `Right`).
- `FileAnchor` keeps its line-range fields private and validates `end_line >= start_line` in `new` / `from_row`, so an inverted range is impossible to construct without bypassing the public API. `InvalidLineRange` is a typed error.

### Wiring — `src/models/mod.rs`

`pub mod aivcs_review;` with `#[allow(dead_code)]` (slice 2 has no HTTP route yet) plus a glob re-export so later slices import from `crate::models::*`.

### CRUD helpers + SQL constants — `src/db.rs`

Per-table SQL constants for every read and write, plus async helpers:

- `insert_review_thread`, `get_review_thread`, `list_review_threads_for_review`, `update_review_thread_status`
- `insert_review_comment`, `list_review_comments_for_thread`
- `insert_review_thread_resolution`, `get_review_thread_resolution`
- `insert_file_anchor`, `list_file_anchors_for_thread`

Plus four internal row types (`ReviewThreadRow`, `ReviewCommentRow`, `ReviewThreadResolutionRow`, `FileAnchorRow`) that hydrate enums via `from_sql` / `from_sql_actor` / `FileAnchor::from_row` — so any value not matching the enum domain is dropped at the storage boundary rather than panicking in the UI.

All SQL binds `tenant_id` as `?1`. The CRUD helpers and SQL constants are `#[allow(dead_code)]` until slice-3+ HTTP routes consume them — wasm `-D warnings` stays green.

## Tests

14 new tests (all green):

- `models::aivcs_review::tests` (11):
  - `review_thread_status_sql_round_trip`, `review_thread_status_serde_round_trip`
  - `resolution_sql_round_trip`, `anchor_side_sql_round_trip`
  - `comment_actor_parses_human_jane`, `comment_actor_parses_agent_optimizer_7`, `comment_actor_rejects_malformed_strings`, `comment_actor_id_may_contain_colons`
  - `file_anchor_accepts_valid_line_ranges`, `file_anchor_rejects_inverted_line_ranges`, `file_anchor_from_row_validates_too`
  - `review_thread_round_trip`, `review_comment_round_trip`, `review_thread_resolution_round_trip`
- `db::tests` (3):
  - `cross_tenant_sql_aivcs_review_thread_select_filters_on_tenant_id` — pins every SELECT to `WHERE tenant_id = ?1`
  - `cross_tenant_sql_aivcs_review_inserts_lead_with_tenant_id` — pins every INSERT to `tenant_id` as the first column / `?1`
  - `cross_tenant_sql_aivcs_review_thread_update_scopes_to_tenant` — pins the UPDATE to `WHERE tenant_id = ?1 AND id = ?2`

These mirror the existing WS8 cross-tenant SQL-shape pattern.

## Verification

All gates clean:

```
RUSTFLAGS="-D warnings" cargo check --target wasm32-unknown-unknown -p data-fabric-worker
    Finished `dev` profile

RUSTFLAGS="-D warnings --cfg=coverage" cargo check --tests -p data-fabric-worker
    Finished `dev` profile

cargo test -p data-fabric-worker --lib
    test result: ok. 408 passed; 0 failed

grep -rn '/fabric/' src/ migrations/   # empty (slice 0 doc check)
```

## Scope notes — what is NOT in this slice

Issue #148 has many sub-scopes. To keep this slice reviewable, the following are explicitly out of scope and will land in their own slices:

- **Slice 1 (event taxonomy)** — `models::aivcs` and the `aivcs.*` / `human.*` / `agent.*` event types. This slice intentionally does not depend on slice 1; `CommentActor` re-uses the `human:<id>` / `agent:<id>` actor convention without importing the slice-1 module.
- **HTTP routes** — no new `/v1/...` endpoints. The CRUD helpers exist for the projection follower and (later) BFF; the routes ship in slice 3+.
- **Projection follower** — the process that reads events and writes these tables. Out of scope.
- **`change_set` entity (issue #148 §5)** — the `change_set_id` column is nullable here precisely because the `change_set` table itself is a later slice.
- **Pause / resume commands (issue #148 §3)** — separate slice.
- **Backfill jobs** — pre-existing tenants will have zero rows on first deploy; no backfill needed.

## Multi-tenancy / safety

- Every table leads with `tenant_id` in its PRIMARY KEY.
- Every SQL statement binds `tenant_id` as `?1` — pinned by the `cross_tenant_sql_aivcs_*` tests.
- All migrations use `IF NOT EXISTS` and are idempotent.
- No secrets in any file or commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)