### PR TITLE
feat(aivcs): add HTTP routes for AIVCS projections and ci_check_run

### DIFF
--- a/migrations/0019_aivcs_ci_check_run.sql
+++ b/migrations/0019_aivcs_ci_check_run.sql
@@ -1,0 +1,17 @@
+-- AIVCS CI check run projection (issue #148).
+--
+-- Tracks CI checks for a change_set.
+
+CREATE TABLE IF NOT EXISTS ci_check_run (
+    tenant_id TEXT NOT NULL DEFAULT '',
+    id TEXT NOT NULL,
+    change_set_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL, -- queued | in_progress | completed
+    conclusion TEXT,      -- success | failure | neutral | cancelled | timed_out | action_required | skipped
+    url TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (tenant_id, id)
+);
+CREATE INDEX IF NOT EXISTS idx_ci_check_run_tenant_change_set
+    ON ci_check_run(tenant_id, change_set_id);

--- a/migrations/0020_aivcs_branches.sql
+++ b/migrations/0020_aivcs_branches.sql
@@ -1,0 +1,17 @@
+-- AIVCS branches projection (issue #148).
+--
+-- Tracks branches for a repository.
+
+CREATE TABLE IF NOT EXISTS branch (
+    tenant_id TEXT NOT NULL DEFAULT '',
+    id TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    name TEXT NOT NULL,
+    head_sha TEXT NOT NULL,
+    agent_owner TEXT,
+    status TEXT NOT NULL, -- active | merged | abandoned
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (tenant_id, id)
+);
+CREATE INDEX IF NOT EXISTS idx_branch_tenant_repo
+    ON branch(tenant_id, repo);

--- a/src/db.rs
+++ b/src/db.rs
@@ -5584,3 +5584,122 @@ mod tests {
         }
     }
 }
+
+// ── AIVCS: ci_check_run DB layer ─────────────────────────────────────────────
+
+pub async fn list_ci_check_runs_for_change_set(
+    d1: &worker::D1Database,
+    tenant_id: &str,
+    change_set_id: &str,
+    limit: u32,
+) -> Result<Vec<models::aivcs::CiCheckRun>> {
+    let sql = "SELECT id, change_set_id, name, status, conclusion, url, created_at \
+               FROM ci_check_run \
+               WHERE tenant_id = ?1 AND change_set_id = ?2 \
+               ORDER BY created_at DESC \
+               LIMIT ?3";
+    let stmt = d1.prepare(sql)
+        .bind(&[
+            tenant_id.into(),
+            change_set_id.into(),
+            limit.into(),
+        ])?;
+    let result = stmt.all().await?;
+    let mut runs = Vec::new();
+    for row in result.results::<serde_json::Value>()? {
+        runs.push(models::aivcs::CiCheckRun {
+            id: row.get("id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            change_set_id: row.get("change_set_id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            name: row.get("name").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            status: row.get("status").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            conclusion: row.get("conclusion").and_then(|v| v.as_str()).map(|s| s.to_string()),
+            url: row.get("url").and_then(|v| v.as_str()).map(|s| s.to_string()),
+            created_at: row.get("created_at").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        });
+    }
+    Ok(runs)
+}
+
+// ── AIVCS: events_bronze DB layer ────────────────────────────────────────────
+
+pub async fn list_events_bronze(
+    d1: &worker::D1Database,
+    tenant_id: &str,
+    since: Option<&str>,
+    limit: u32,
+) -> Result<Vec<serde_json::Value>> {
+    let sql = if since.is_some() {
+        "SELECT id, run_id, thread_id, event_type, node_id, actor, payload, created_at \
+         FROM events_bronze \
+         WHERE tenant_id = ?1 AND created_at > ?2 \
+         ORDER BY created_at ASC \
+         LIMIT ?3"
+    } else {
+        "SELECT id, run_id, thread_id, event_type, node_id, actor, payload, created_at \
+         FROM events_bronze \
+         WHERE tenant_id = ?1 \
+         ORDER BY created_at ASC \
+         LIMIT ?2"
+    };
+
+    let stmt = if let Some(s) = since {
+        d1.prepare(sql).bind(&[tenant_id.into(), s.into(), limit.into()])?
+    } else {
+        d1.prepare(sql).bind(&[tenant_id.into(), limit.into()])?
+    };
+
+    let result = stmt.all().await?;
+    let mut events = Vec::new();
+    for row in result.results::<serde_json::Value>()? {
+        let mut evt = serde_json::Map::new();
+        evt.insert("id".into(), row.get("id").unwrap_or(&serde_json::Value::Null).clone());
+        evt.insert("run_id".into(), row.get("run_id").unwrap_or(&serde_json::Value::Null).clone());
+        evt.insert("thread_id".into(), row.get("thread_id").unwrap_or(&serde_json::Value::Null).clone());
+        evt.insert("event_type".into(), row.get("event_type").unwrap_or(&serde_json::Value::Null).clone());
+        evt.insert("node_id".into(), row.get("node_id").unwrap_or(&serde_json::Value::Null).clone());
+        evt.insert("actor".into(), row.get("actor").unwrap_or(&serde_json::Value::Null).clone());
+        if let Some(payload_str) = row.get("payload").and_then(|v| v.as_str()) {
+            if let Ok(payload_json) = serde_json::from_str::<serde_json::Value>(payload_str) {
+                evt.insert("payload".into(), payload_json);
+            }
+        }
+        evt.insert("created_at".into(), row.get("created_at").unwrap_or(&serde_json::Value::Null).clone());
+        events.push(serde_json::Value::Object(evt));
+    }
+    Ok(events)
+}
+
+// ── AIVCS: branch DB layer ───────────────────────────────────────────────────
+
+pub async fn list_branches_by_repo(
+    d1: &worker::D1Database,
+    tenant_id: &str,
+    repo: &str,
+    limit: u32,
+) -> Result<Vec<models::aivcs::Branch>> {
+    let sql = "SELECT id, repo, name, head_sha, agent_owner, status, created_at \
+               FROM branch \
+               WHERE tenant_id = ?1 AND repo = ?2 \
+               ORDER BY created_at DESC \
+               LIMIT ?3";
+    let stmt = d1.prepare(sql)
+        .bind(&[
+            tenant_id.into(),
+            repo.into(),
+            limit.into(),
+        ])?;
+    let result = stmt.all().await?;
+    let mut branches = Vec::new();
+    for row in result.results::<serde_json::Value>()? {
+        branches.push(models::aivcs::Branch {
+            id: row.get("id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            repo: row.get("repo").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            name: row.get("name").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            head_sha: row.get("head_sha").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            agent_owner: row.get("agent_owner").and_then(|v| v.as_str()).map(|s| s.to_string()),
+            status: row.get("status").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            created_at: row.get("created_at").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        });
+    }
+    Ok(branches)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2174,6 +2174,113 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 },
             )
         })
+        // ── AIVCS: change_set routes (issue #148) ────────────────
+        .get_async("/v1/change-sets", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let url = req.url().map_err(|_| Error::RustError("invalid url".into()))?;
+            let params = url.query_pairs().collect::<std::collections::HashMap<_, _>>();
+            let repo = params.get("repo").map(|s| s.as_ref());
+            let limit = pagination::clamp_limit(params.get("limit").and_then(|s| s.parse().ok()));
+            let d1 = ctx.env.d1("DB")?;
+            if let Some(r) = repo {
+                let list = db::list_change_sets_by_repo(&d1, &tenant_ctx.tenant_id, r, limit).await?;
+                Response::from_json(&serde_json::json!({ "change_sets": list }))
+            } else {
+                Response::error("missing required query parameter: repo", 400)
+            }
+        })
+        .get_async("/v1/change-sets/:id", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let id = ctx.param("id").unwrap().to_string();
+            let d1 = ctx.env.d1("DB")?;
+            match db::get_change_set(&d1, &tenant_ctx.tenant_id, &id).await? {
+                Some(cs) => Response::from_json(&cs),
+                None => Response::error("change_set not found", 404),
+            }
+        })
+        // ── AIVCS: review projections routes (issue #148) ────────
+        .get_async("/v1/review-threads", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let url = req.url().map_err(|_| Error::RustError("invalid url".into()))?;
+            let params = url.query_pairs().collect::<std::collections::HashMap<_, _>>();
+            let review_id = params.get("review_id").map(|s| s.as_ref());
+            let d1 = ctx.env.d1("DB")?;
+            if let Some(rid) = review_id {
+                let list = db::list_review_threads_for_review(&d1, &tenant_ctx.tenant_id, rid, 100).await?;
+                Response::from_json(&serde_json::json!({ "review_threads": list }))
+            } else {
+                Response::error("missing required query parameter: review_id", 400)
+            }
+        })
+        .get_async("/v1/review-threads/:id/comments", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let thread_id = ctx.param("id").unwrap().to_string();
+            let d1 = ctx.env.d1("DB")?;
+            let list = db::list_review_comments_for_thread(&d1, &tenant_ctx.tenant_id, &thread_id, 100).await?;
+            Response::from_json(&serde_json::json!({ "comments": list }))
+        })
+        .get_async("/v1/review-threads/:id/anchors", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let thread_id = ctx.param("id").unwrap().to_string();
+            let d1 = ctx.env.d1("DB")?;
+            let list = db::list_file_anchors_for_thread(&d1, &tenant_ctx.tenant_id, &thread_id, 100).await?;
+            Response::from_json(&serde_json::json!({ "file_anchors": list }))
+        })
+        .get_async("/v1/human-decisions", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let url = req.url().map_err(|_| Error::RustError("invalid url".into()))?;
+            let params = url.query_pairs().collect::<std::collections::HashMap<_, _>>();
+            let review_id = params.get("review_id").map(|s| s.as_ref());
+            let d1 = ctx.env.d1("DB")?;
+            if let Some(rid) = review_id {
+                let list = db::list_human_decisions_by_review(&d1, &tenant_ctx.tenant_id, rid).await?;
+                Response::from_json(&serde_json::json!({ "human_decisions": list }))
+            } else {
+                Response::error("missing required query parameter: review_id", 400)
+            }
+        })
+
+        .get_async("/v1/ci-check-runs", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let url = req.url().map_err(|_| Error::RustError("invalid url".into()))?;
+            let params = url.query_pairs().collect::<std::collections::HashMap<_, _>>();
+            let change_set_id = params.get("change_set_id").map(|s| s.as_ref());
+            let limit = pagination::clamp_limit(params.get("limit").and_then(|s| s.parse().ok()));
+            let d1 = ctx.env.d1("DB")?;
+            if let Some(cs_id) = change_set_id {
+                let list = db::list_ci_check_runs_for_change_set(&d1, &tenant_ctx.tenant_id, cs_id, limit).await?;
+                Response::from_json(&serde_json::json!({ "ci_check_runs": list }))
+            } else {
+                Response::error("missing required query parameter: change_set_id", 400)
+            }
+        })
+
+        .get_async("/v1/events", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let url = req.url().map_err(|_| Error::RustError("invalid url".into()))?;
+            let params = url.query_pairs().collect::<std::collections::HashMap<_, _>>();
+            let since = params.get("since").map(|s| s.as_ref());
+            let limit = pagination::clamp_limit(params.get("limit").and_then(|s| s.parse().ok()));
+            let d1 = ctx.env.d1("DB")?;
+            let list = db::list_events_bronze(&d1, &tenant_ctx.tenant_id, since, limit).await?;
+            Response::from_json(&serde_json::json!({ "events": list }))
+        })
+
+        .get_async("/v1/branches", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let url = req.url().map_err(|_| Error::RustError("invalid url".into()))?;
+            let params = url.query_pairs().collect::<std::collections::HashMap<_, _>>();
+            let repo = params.get("repo").map(|s| s.as_ref());
+            let limit = pagination::clamp_limit(params.get("limit").and_then(|s| s.parse().ok()));
+            let d1 = ctx.env.d1("DB")?;
+            if let Some(r) = repo {
+                let list = db::list_branches_by_repo(&d1, &tenant_ctx.tenant_id, r, limit).await?;
+                Response::from_json(&serde_json::json!({ "branches": list }))
+            } else {
+                Response::error("missing required query parameter: repo", 400)
+            }
+        })
+
         .run(req, env)
         .await;
 

--- a/src/models/aivcs.rs
+++ b/src/models/aivcs.rs
@@ -262,3 +262,25 @@ mod tests {
         assert!(payload.confidence.is_none());
     }
 }
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct CiCheckRun {
+    pub id: String,
+    pub change_set_id: String,
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub url: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct Branch {
+    pub id: String,
+    pub repo: String,
+    pub name: String,
+    pub head_sha: String,
+    pub agent_owner: Option<String>,
+    pub status: String,
+    pub created_at: String,
+}


### PR DESCRIPTION
## Summary
Adds the missing HTTP routes to expose the AIVCS projections to the BFF:
- `GET /v1/change-sets`
- `GET /v1/change-sets/:id`
- `GET /v1/review-threads`
- `GET /v1/review-threads/:id/comments`
- `GET /v1/review-threads/:id/anchors`
- `GET /v1/human-decisions`
- `GET /v1/ci-check-runs`
- `GET /v1/events`

Also adds the missing `ci_check_run` projection and DB layer.

This unblocks the `aivcs-api` BFF integration.

Closes #157, #158, #159, #160.
Refs: stevedores-org/aivcs-api#10, #148

Made with [Cursor](https://cursor.com)