### PR TITLE
AIVCS: add pull request projection

### DIFF
--- a/data-fabric-client/src/lib.rs
+++ b/data-fabric-client/src/lib.rs
@@ -205,6 +205,11 @@ impl Client {
         self.send_request::<(), Run>(Method::GET, &path, None).await
     }
 
+    pub async fn get_pull_request(&self, id: &str) -> Result<AivcsPullRequest> {
+        let path = format!("/v1/pull-requests/{}", encode_path_segment(id));
+        self.send_request::<(), AivcsPullRequest>(Method::GET, &path, None).await
+    }
+
     // ── WS2 Tasks ──────────────────────────────────────────────────────────
     
     pub async fn create_task(&self, run_id: &str, task: &CreateTask) -> Result<Created> {

--- a/data-fabric-client/src/types.rs
+++ b/data-fabric-client/src/types.rs
@@ -53,6 +53,22 @@ pub struct Created {
     pub status: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AivcsPullRequest {
+    pub id: String,
+    pub repo: String,
+    pub run_id: String,
+    pub title: String,
+    pub status: String,
+    pub source_branch: Option<String>,
+    pub target_branch: Option<String>,
+    pub author: Option<String>,
+    pub summary: Option<String>,
+    pub change_set: serde_json::Value,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
 // WS2 Task types
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Task {

--- a/data-fabric-client/tests/client_tests.rs
+++ b/data-fabric-client/tests/client_tests.rs
@@ -43,3 +43,44 @@ async fn test_client_headers_and_response() {
 
     server_handle.await.unwrap();
 }
+
+#[tokio::test]
+async fn test_client_get_pull_request_encodes_id() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let server_handle = task::spawn_blocking(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buffer = [0; 2048];
+        let bytes_read = stream.read(&mut buffer).unwrap();
+        let request_str = String::from_utf8_lossy(&buffer[..bytes_read]);
+
+        assert!(request_str.starts_with("GET /v1/pull-requests/owner%2Frepo%231 HTTP/1.1"));
+
+        let response = concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "Content-Type: application/json\r\n",
+            "\r\n",
+            r#"{"id":"owner/repo#1","repo":"stevedores-org/aivcs-api","run_id":"run-1","title":"Review","status":"open","source_branch":"feature/a","target_branch":"main","author":"codex","summary":"Ready","change_set":{"id":"owner/repo#1"},"created_at":"2026-06-12T00:00:00.000Z","updated_at":"2026-06-12T00:00:00.000Z"}"#
+        );
+        stream.write_all(response.as_bytes()).unwrap();
+        stream.flush().unwrap();
+    });
+
+    let config = ClientConfig {
+        base_url: format!("http://127.0.0.1:{}", port),
+        tenant_id: "test-tenant".to_string(),
+        tenant_role: "builder".to_string(),
+        cf_client_id: None,
+        cf_client_secret: None,
+    };
+
+    let client = Client::new(config);
+    let pr = client.get_pull_request("owner/repo#1").await.unwrap();
+
+    assert_eq!(pr.id, "owner/repo#1");
+    assert_eq!(pr.repo, "stevedores-org/aivcs-api");
+    assert_eq!(pr.change_set["id"], "owner/repo#1");
+
+    server_handle.await.unwrap();
+}

--- a/migrations/0015_aivcs_pull_requests.sql
+++ b/migrations/0015_aivcs_pull_requests.sql
@@ -1,0 +1,26 @@
+-- AIVCS Gold projection for review queue / pull request workspace reads.
+-- Source of truth starts as runs.metadata.aivcs.change_set.
+
+CREATE TABLE IF NOT EXISTS gold_aivcs_review_queue (
+    tenant_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    status TEXT NOT NULL,
+    source_branch TEXT,
+    target_branch TEXT,
+    author TEXT,
+    summary TEXT,
+    change_set TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, id),
+    FOREIGN KEY (run_id) REFERENCES runs(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gold_aivcs_review_queue_tenant_updated
+    ON gold_aivcs_review_queue(tenant_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_gold_aivcs_review_queue_tenant_repo_status
+    ON gold_aivcs_review_queue(tenant_id, repo, status);

--- a/src/db.rs
+++ b/src/db.rs
@@ -750,7 +750,114 @@ pub async fn create_run(
     ])?
     .run()
     .await?;
+    if let Some(projection) = aivcs_projection_from_run(tenant_id, id, body, &now) {
+        upsert_aivcs_pull_request(db, &projection).await?;
+    }
     Ok(())
+}
+
+async fn upsert_aivcs_pull_request(db: &D1Database, pr: &AivcsPullRequestUpsert) -> Result<()> {
+    db.prepare(
+        "INSERT INTO gold_aivcs_review_queue (
+            tenant_id, id, repo, run_id, title, status, source_branch, target_branch,
+            author, summary, change_set, created_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(tenant_id, id) DO UPDATE SET
+            repo = excluded.repo,
+            run_id = excluded.run_id,
+            title = excluded.title,
+            status = excluded.status,
+            source_branch = excluded.source_branch,
+            target_branch = excluded.target_branch,
+            author = excluded.author,
+            summary = excluded.summary,
+            change_set = excluded.change_set,
+            updated_at = excluded.updated_at",
+    )
+    .bind(&[
+        JsValue::from_str(&pr.tenant_id),
+        JsValue::from_str(&pr.id),
+        JsValue::from_str(&pr.repo),
+        JsValue::from_str(&pr.run_id),
+        JsValue::from_str(&pr.title),
+        JsValue::from_str(&pr.status),
+        opt_string(&pr.source_branch),
+        opt_string(&pr.target_branch),
+        opt_string(&pr.author),
+        opt_string(&pr.summary),
+        JsValue::from_str(&pr.change_set),
+        JsValue::from_str(&pr.created_at),
+        JsValue::from_str(&pr.updated_at),
+    ])?
+    .run()
+    .await?;
+    Ok(())
+}
+
+pub async fn get_aivcs_pull_request(
+    db: &D1Database,
+    tenant_id: &str,
+    id: &str,
+) -> Result<Option<AivcsPullRequestResponse>> {
+    let row: Option<AivcsPullRequestRow> = db
+        .prepare(
+            "SELECT id, repo, run_id, title, status, source_branch, target_branch,
+                    author, summary, change_set, created_at, updated_at
+             FROM gold_aivcs_review_queue
+             WHERE tenant_id = ?1 AND id = ?2",
+        )
+        .bind(&[JsValue::from_str(tenant_id), JsValue::from_str(id)])?
+        .first(None)
+        .await?;
+    Ok(row.map(|r| r.into_response()))
+}
+
+fn opt_string(s: &Option<String>) -> JsValue {
+    match s {
+        Some(s) => JsValue::from_str(s),
+        None => JsValue::NULL,
+    }
+}
+
+fn aivcs_projection_from_run(
+    tenant_id: &str,
+    run_id: &str,
+    body: &models::CreateRun,
+    now: &str,
+) -> Option<AivcsPullRequestUpsert> {
+    let change_set = body.metadata.as_ref()?.get("aivcs")?.get("change_set")?;
+    let id = json_string(change_set, &["id", "number", "pull_request_id"])?;
+    let title = json_string(change_set, &["title"]).unwrap_or_else(|| id.clone());
+    let status = json_string(change_set, &["status", "state"]).unwrap_or_else(|| "open".into());
+    let created_at = json_string(change_set, &["created_at"]).unwrap_or_else(|| now.into());
+    let updated_at = json_string(change_set, &["updated_at"]).unwrap_or_else(|| now.into());
+    let change_set_json = serde_json::to_string(change_set).ok()?;
+
+    Some(AivcsPullRequestUpsert {
+        tenant_id: tenant_id.into(),
+        id,
+        repo: body.repo.clone(),
+        run_id: run_id.into(),
+        title,
+        status,
+        source_branch: json_string(change_set, &["source_branch", "head_ref", "head"]),
+        target_branch: json_string(change_set, &["target_branch", "base_ref", "base"]),
+        author: json_string(change_set, &["author", "actor"]),
+        summary: json_string(change_set, &["summary", "description"]),
+        change_set: change_set_json,
+        created_at,
+        updated_at,
+    })
+}
+
+fn json_string(value: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .filter_map(|key| value.get(*key))
+        .find_map(|v| match v {
+            serde_json::Value::String(s) if !s.trim().is_empty() => Some(s.clone()),
+            serde_json::Value::Number(n) => Some(n.to_string()),
+            _ => None,
+        })
 }
 
 /// List runs for `tenant_id` ordered by `(created_at DESC, id DESC)`.
@@ -3491,6 +3598,74 @@ pub struct RunResponse {
     pub resumed_at: Option<String>,
 }
 
+#[derive(Debug, PartialEq)]
+struct AivcsPullRequestUpsert {
+    tenant_id: String,
+    id: String,
+    repo: String,
+    run_id: String,
+    title: String,
+    status: String,
+    source_branch: Option<String>,
+    target_branch: Option<String>,
+    author: Option<String>,
+    summary: Option<String>,
+    change_set: String,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct AivcsPullRequestRow {
+    pub id: String,
+    pub repo: String,
+    pub run_id: String,
+    pub title: String,
+    pub status: String,
+    pub source_branch: Option<String>,
+    pub target_branch: Option<String>,
+    pub author: Option<String>,
+    pub summary: Option<String>,
+    pub change_set: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl AivcsPullRequestRow {
+    pub fn into_response(self) -> AivcsPullRequestResponse {
+        AivcsPullRequestResponse {
+            id: self.id,
+            repo: self.repo,
+            run_id: self.run_id,
+            title: self.title,
+            status: self.status,
+            source_branch: self.source_branch,
+            target_branch: self.target_branch,
+            author: self.author,
+            summary: self.summary,
+            change_set: serde_json::from_str(&self.change_set).unwrap_or(serde_json::Value::Null),
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct AivcsPullRequestResponse {
+    pub id: String,
+    pub repo: String,
+    pub run_id: String,
+    pub title: String,
+    pub status: String,
+    pub source_branch: Option<String>,
+    pub target_branch: Option<String>,
+    pub author: Option<String>,
+    pub summary: Option<String>,
+    pub change_set: serde_json::Value,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
 #[derive(Debug, serde::Deserialize)]
 pub struct Ws2TaskRow {
     pub id: String,
@@ -5069,6 +5244,95 @@ mod tests {
         };
 
         assert!(build_entity_refs(&evt).is_none());
+    }
+
+    #[test]
+    fn aivcs_projection_from_run_extracts_change_set() {
+        let body = models::CreateRun {
+            repo: "stevedores-org/aivcs-api".into(),
+            trigger: Some("pull_request".into()),
+            actor: Some("codex".into()),
+            metadata: Some(serde_json::json!({
+                "aivcs": {
+                    "change_set": {
+                        "id": "11",
+                        "title": "Fix merge conflicts",
+                        "status": "ready_for_review",
+                        "source_branch": "codex/fmc-pr11",
+                        "target_branch": "main",
+                        "author": "codex",
+                        "summary": "Resolved PR conflicts",
+                        "labels": ["aivcs"]
+                    }
+                }
+            })),
+        };
+
+        let projection =
+            aivcs_projection_from_run("tenant-a", "run-1", &body, "2026-06-12T00:00:00.000Z")
+                .expect("projection");
+
+        assert_eq!(projection.tenant_id, "tenant-a");
+        assert_eq!(projection.id, "11");
+        assert_eq!(projection.repo, "stevedores-org/aivcs-api");
+        assert_eq!(projection.run_id, "run-1");
+        assert_eq!(projection.title, "Fix merge conflicts");
+        assert_eq!(projection.status, "ready_for_review");
+        assert_eq!(projection.source_branch.as_deref(), Some("codex/fmc-pr11"));
+        assert_eq!(projection.target_branch.as_deref(), Some("main"));
+        assert_eq!(projection.author.as_deref(), Some("codex"));
+        assert_eq!(projection.summary.as_deref(), Some("Resolved PR conflicts"));
+        assert_eq!(projection.created_at, "2026-06-12T00:00:00.000Z");
+        assert_eq!(projection.updated_at, "2026-06-12T00:00:00.000Z");
+        let change_set: serde_json::Value = serde_json::from_str(&projection.change_set).unwrap();
+        assert_eq!(change_set["labels"][0], "aivcs");
+    }
+
+    #[test]
+    fn aivcs_projection_from_run_accepts_numeric_change_set_id() {
+        let body = models::CreateRun {
+            repo: "stevedores-org/data-fabric".into(),
+            trigger: None,
+            actor: None,
+            metadata: Some(serde_json::json!({
+                "aivcs": {
+                    "change_set": {
+                        "number": 158,
+                        "state": "open",
+                        "head_ref": "feature/change-set",
+                        "base_ref": "main"
+                    }
+                }
+            })),
+        };
+
+        let projection =
+            aivcs_projection_from_run("tenant-a", "run-2", &body, "2026-06-12T00:00:00.000Z")
+                .expect("projection");
+
+        assert_eq!(projection.id, "158");
+        assert_eq!(projection.title, "158");
+        assert_eq!(projection.status, "open");
+        assert_eq!(projection.source_branch.as_deref(), Some("feature/change-set"));
+        assert_eq!(projection.target_branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn aivcs_projection_from_run_ignores_runs_without_change_set() {
+        let body = models::CreateRun {
+            repo: "stevedores-org/data-fabric".into(),
+            trigger: None,
+            actor: None,
+            metadata: Some(serde_json::json!({ "ref": "main" })),
+        };
+
+        assert!(aivcs_projection_from_run(
+            "tenant-a",
+            "run-3",
+            &body,
+            "2026-06-12T00:00:00.000Z"
+        )
+        .is_none());
     }
 
     // ── Pagination helpers: list_policy_rules / list_agents ─────

--- a/src/db.rs
+++ b/src/db.rs
@@ -826,8 +826,16 @@ fn aivcs_projection_from_run(
     now: &str,
 ) -> Option<AivcsPullRequestUpsert> {
     let change_set = body.metadata.as_ref()?.get("aivcs")?.get("change_set")?;
-    let id = json_string(change_set, &["id", "number", "pull_request_id"])?;
-    let title = json_string(change_set, &["title"]).unwrap_or_else(|| id.clone());
+    let explicit_id = json_string(change_set, &["id"]);
+    let source_id = explicit_id
+        .clone()
+        .or_else(|| json_string(change_set, &["number", "pull_request_id"]))?;
+    let id = if explicit_id.is_some() {
+        source_id.clone()
+    } else {
+        format!("{}#{}", body.repo, source_id)
+    };
+    let title = json_string(change_set, &["title"]).unwrap_or_else(|| source_id.clone());
     let status = json_string(change_set, &["status", "state"]).unwrap_or_else(|| "open".into());
     let created_at = json_string(change_set, &["created_at"]).unwrap_or_else(|| now.into());
     let updated_at = json_string(change_set, &["updated_at"]).unwrap_or_else(|| now.into());
@@ -5289,7 +5297,7 @@ mod tests {
     }
 
     #[test]
-    fn aivcs_projection_from_run_accepts_numeric_change_set_id() {
+    fn aivcs_projection_from_run_scopes_numeric_pr_id_by_repo() {
         let body = models::CreateRun {
             repo: "stevedores-org/data-fabric".into(),
             trigger: None,
@@ -5310,7 +5318,7 @@ mod tests {
             aivcs_projection_from_run("tenant-a", "run-2", &body, "2026-06-12T00:00:00.000Z")
                 .expect("projection");
 
-        assert_eq!(projection.id, "158");
+        assert_eq!(projection.id, "stevedores-org/data-fabric#158");
         assert_eq!(projection.title, "158");
         assert_eq!(projection.status, "open");
         assert_eq!(projection.source_branch.as_deref(), Some("feature/change-set"));

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -236,6 +236,9 @@ pub mod aivcs {
             meta.insert("branch".into(), serde_json::Value::String(branch.clone()));
         }
         if let Some(ref user_meta) = evt.metadata {
+            if let Some(aivcs_meta) = user_meta.get("aivcs") {
+                meta.insert("aivcs".into(), aivcs_meta.clone());
+            }
             meta.insert("metadata".into(), user_meta.clone());
         }
 
@@ -836,6 +839,33 @@ mod tests {
         let meta = run.metadata.unwrap();
         assert_eq!(meta["source"], "aivcs");
         assert_eq!(meta["commit_sha"], "abc123");
+    }
+
+    #[test]
+    fn aivcs_adapt_to_run_promotes_aivcs_metadata() {
+        let evt = aivcs::PipelineEvent {
+            pipeline_id: "p1".into(),
+            repo: "stevedores-org/data-fabric".into(),
+            event_type: aivcs::PipelineEventType::PipelineStart,
+            commit_sha: None,
+            branch: None,
+            actor: "ci-bot".into(),
+            artifacts: None,
+            metadata: Some(serde_json::json!({
+                "aivcs": {
+                    "change_set": {
+                        "number": 162,
+                        "title": "AIVCS projection"
+                    }
+                }
+            })),
+        };
+
+        let run = aivcs::adapt_to_run(&evt).unwrap();
+        let meta = run.metadata.unwrap();
+
+        assert_eq!(meta["aivcs"]["change_set"]["number"], 162);
+        assert_eq!(meta["metadata"]["aivcs"]["change_set"]["number"], 162);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,19 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 None => errors::error_response("RUN_NOT_FOUND", "run not found", 404),
             }
         })
+        .get_async("/v1/pull-requests/:id", |req, ctx| async move {
+            let tenant_ctx = tenant::tenant_from_request(&req)?;
+            let id = ctx.param("id").unwrap().to_string();
+            let d1 = ctx.env.d1("DB")?;
+            match db::get_aivcs_pull_request(&d1, &tenant_ctx.tenant_id, &id).await? {
+                Some(pr) => Response::from_json(&pr),
+                None => errors::error_response(
+                    "PULL_REQUEST_NOT_FOUND",
+                    "pull request not found",
+                    404,
+                ),
+            }
+        })
         // ── AIVCS issue #148 slice 4: explicit run pause/resume ─────
         //
         // These are scoped to runs only — task-level pause/resume is a

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -259,6 +259,50 @@ pub fn get_openapi_spec() -> &'static str {
         }
       }
     },
+    "/v1/pull-requests/{id}": {
+      "get": {
+        "summary": "Get AIVCS Pull Request",
+        "description": "Returns the AIVCS review queue projection sourced from runs.metadata.aivcs.change_set.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AIVCS pull request projection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id", "repo", "run_id", "title", "status", "change_set", "created_at", "updated_at"],
+                  "properties": {
+                    "id": { "type": "string" },
+                    "repo": { "type": "string" },
+                    "run_id": { "type": "string" },
+                    "title": { "type": "string" },
+                    "status": { "type": "string" },
+                    "source_branch": { "type": "string" },
+                    "target_branch": { "type": "string" },
+                    "author": { "type": "string" },
+                    "summary": { "type": "string" },
+                    "change_set": { "type": "object" },
+                    "created_at": { "type": "string", "format": "date-time" },
+                    "updated_at": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pull request projection not found"
+          }
+        }
+      }
+    },
     "/v1/checkpoints": {
       "post": {
         "summary": "Save Checkpoint",


### PR DESCRIPTION
## Summary
- add gold_aivcs_review_queue D1 projection sourced from runs.metadata.aivcs.change_set
- project AIVCS change_set metadata during run creation and expose GET /v1/pull-requests/:id
- document the endpoint in OpenAPI and add typed data-fabric-client support

Closes #158

## Tests
- cargo test --lib
- cargo test -p data-fabric-client
- cargo test --workspace

## Notes
- cargo fmt --all -- --check currently reports pre-existing rustfmt drift across multiple files; I left the feature patch scoped instead of committing a broad formatting sweep.