### PR TITLE
fix(bug-hunt): resolve swallowed errors and unwrap panics in src/

### DIFF
--- a/src/gemini_service.rs
+++ b/src/gemini_service.rs
@@ -62,7 +62,7 @@ pub async fn summarize_telemetry_batch(
             },
         };
         
-        jsonl.push_str(&serde_json::to_string(&req).unwrap());
+        jsonl.push_str(&serde_json::to_string(&req).map_err(|e| Error::RustError(e.to_string()))?);
         jsonl.push('\n');
     }
 

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -837,7 +837,7 @@ pub mod gemini {
                 .map_err(|e| format!("{:?}", e))?;
             opts.with_headers(headers);
             opts.with_body(Some(JsValue::from_str(
-                &serde_json::to_string(&metadata).unwrap(),
+                &serde_json::to_string(&metadata).map_err(|e| format!("{:?}", e))?,
             )));
 
             let req = worker::Request::new_with_init(&url, &opts).map_err(|e| format!("{:?}", e))?;
@@ -915,9 +915,9 @@ pub mod gemini {
             });
 
             if let Some(name) = display_name {
-                body.as_object_mut()
-                    .unwrap()
-                    .insert("display_name".to_string(), serde_json::json!(name));
+                if let Some(obj) = body.as_object_mut() {
+                    obj.insert("display_name".to_string(), serde_json::json!(name));
+                }
             }
 
             let mut opts = worker::RequestInit::new();
@@ -929,7 +929,7 @@ pub mod gemini {
                 .map_err(|e| format!("{:?}", e))?;
             opts.with_headers(headers);
             opts.with_body(Some(JsValue::from_str(
-                &serde_json::to_string(&body).unwrap(),
+                &serde_json::to_string(&body).map_err(|e| format!("{:?}", e))?,
             )));
 
             let req = worker::Request::new_with_init(&url, &opts).map_err(|e| format!("{:?}", e))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,7 +570,9 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                         "run_id": body.run_id,
                         "tenant_id": tenant_ctx.tenant_id
                     });
-                    let _ = index.insert(&id, vector, metadata).await;
+                    if let Err(e) = index.insert(&id, vector, metadata).await {
+                        worker::console_error!("Failed to insert into Vectorize: {:?}", e);
+                    }
                 }
             }
 

--- a/src/play_do.rs
+++ b/src/play_do.rs
@@ -206,7 +206,7 @@ impl PlayManager {
                 retry_count: 0,
                 max_retries: 3,
                 lease_expires_at: None,
-                created_at: js_sys::Date::new_0().to_iso_string().as_string().unwrap(),
+                created_at: js_sys::Date::new_0().to_iso_string().as_string().unwrap_or_default(),
                 completed_at: None,
                 memory_context: None,
                 tenant_id: Some(state.tenant_id.clone()),

--- a/src/task_do.rs
+++ b/src/task_do.rs
@@ -356,10 +356,10 @@ impl DurableObject for TaskLeaseManager {
                     let now = js_sys::Date::now() as u64;
                     let expires = now + (300 * 1000);
                     task.lease_expires_at = Some(
-                        js_sys::Date::new(&serde_wasm_bindgen::to_value(&expires).unwrap())
+                        js_sys::Date::new(&serde_wasm_bindgen::to_value(&expires).unwrap_or_default())
                             .to_iso_string()
                             .as_string()
-                            .unwrap(),
+                            .unwrap_or_default(),
                     );
 
                     active.insert(task.id.clone(), task.clone());
@@ -398,10 +398,10 @@ impl DurableObject for TaskLeaseManager {
                         let now = js_sys::Date::now() as u64;
                         let expires = now + (300 * 1000);
                         task.lease_expires_at = Some(
-                            js_sys::Date::new(&serde_wasm_bindgen::to_value(&expires).unwrap())
+                            js_sys::Date::new(&serde_wasm_bindgen::to_value(&expires).unwrap_or_default())
                                 .to_iso_string()
                                 .as_string()
-                                .unwrap(),
+                                .unwrap_or_default(),
                         );
 
                         storage.put("active", active).await?;
@@ -429,7 +429,7 @@ impl DurableObject for TaskLeaseManager {
                     task.status = "completed".to_string();
                     task.result = result;
                     task.completed_at =
-                        Some(js_sys::Date::new_0().to_iso_string().as_string().unwrap());
+                        Some(js_sys::Date::new_0().to_iso_string().as_string().unwrap_or_default());
 
                     let job_id = task.job_id.clone();
                     let task_tenant = task.tenant_id.clone();
@@ -514,7 +514,7 @@ impl DurableObject for TaskLeaseManager {
                         task.status = "failed".to_string();
                         task.result = Some(serde_json::json!({ "error": fail_req.error }));
                         task.completed_at =
-                            Some(js_sys::Date::new_0().to_iso_string().as_string().unwrap());
+                            Some(js_sys::Date::new_0().to_iso_string().as_string().unwrap_or_default());
                     }
                     storage.put("active", active).await?;
                     Response::from_json(&task)
@@ -570,7 +570,7 @@ impl DurableObject for TaskLeaseManager {
                     task.result =
                         Some(serde_json::json!({ "error": "lease expired and no retries left" }));
                     task.completed_at =
-                        Some(js_sys::Date::new_0().to_iso_string().as_string().unwrap());
+                        Some(js_sys::Date::new_0().to_iso_string().as_string().unwrap_or_default());
                 }
             }
         }

--- a/src/thread_do.rs
+++ b/src/thread_do.rs
@@ -118,10 +118,10 @@ impl DurableObject for ThreadManager {
                     .get("x-checkpoint-id")?
                     .ok_or_else(|| Error::RustError("missing x-checkpoint-id header".into()))?;
                 let now = js_sys::Date::now() as u64;
-                let created_at = js_sys::Date::new(&serde_wasm_bindgen::to_value(&now).unwrap())
+                let created_at = js_sys::Date::new(&serde_wasm_bindgen::to_value(&now).unwrap_or_default())
                     .to_iso_string()
                     .as_string()
-                    .unwrap();
+                    .unwrap_or_default();
 
                 // PR #132 crr finding (thread_do.rs:44/50): the size was
                 // measured but never compared against the 128 KB limit,


### PR DESCRIPTION
Scope: `src/`

| # | Severity | File | Bug | Fix |
|---|----------|------|-----|-----|
| 1 | high     | src/lib.rs:573 | Vectorize insertion failures are silently swallowed, leading to missing semantic search results for "indexed" memories. | Added `worker::console_error!` logging for Vectorize insertion failures. |
| 2 | high     | src/gemini_service.rs:65 | `unwrap()` on `serde_json::to_string(&req)` could panic the worker if serialization fails. | Replaced `unwrap()` with `map_err` to return `Error::RustError`. |
| 3 | high     | src/integrations.rs:840, 932 | `unwrap()` on JSON body serialization could panic the worker. | Replaced `unwrap()` with `map_err` to return an error string. |
| 4 | high     | src/task_do.rs:359, 401, 432, 517, 573 | `js_sys::Date::new().to_iso_string().as_string().unwrap()` panics if formatting fails. | Replaced `unwrap()` with `unwrap_or_default()` to provide a safe fallback. |
| 5 | smell    | src/integrations.rs:919 | `unwrap()` on `body.as_object_mut()` assumes the JSON value is an object. | Replaced with `if let Some(obj) = body.as_object_mut() { ... }`. |

1. **Vectorize insertion swallowed error**: In `src/lib.rs`, when indexing a memory item, the `index.insert` call was executed as `let _ = index.insert(...)`. If the Vectorize API failed, the error was silently ignored, but the memory item was still reported as "indexed". I added a `console_error!` log to surface these failures.
2. **Gemini service serialization panic**: In `src/gemini_service.rs`, the `serde_json::to_string(&req).unwrap()` call could panic the worker if the `GeminiBatchRequest` failed to serialize. I replaced the `unwrap()` with a `map_err` that returns a proper `Error::RustError`.
3. **Integration serialization panics**: In `src/integrations.rs`, there were multiple `unwrap()` calls on `serde_json::to_string` when building HTTP request bodies. These could panic the worker. I replaced them with `map_err` to return a formatted error string.
4. **Date formatting panics**: In `src/task_do.rs`, `src/thread_do.rs`, and `src/play_do.rs`, there were multiple instances of `js_sys::Date::new().to_iso_string().as_string().unwrap()`. If the date formatting failed, this would panic. I replaced these with `unwrap_or_default()` to provide a safe empty string fallback.
5. **JSON object mutation smell**: In `src/integrations.rs`, `body.as_object_mut().unwrap()` was used to insert a field into a JSON object. While safe because the object was constructed locally, it's a smell. I replaced it with an `if let Some` check.
