### PR TITLE
chore: point Nix substituter at nix-cache.lornu.ai

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
   description = "data-fabric — Cloudflare-native data fabric for autonomous AI agent builders";
 
   nixConfig = {
-    extra-substituters = [ "https://nix-cache.stevedores.org/" ];
-    extra-trusted-substituters = [ "https://nix-cache.stevedores.org/" ];
+    extra-substituters = [ "https://nix-cache.lornu.ai" ];
+    extra-trusted-substituters = [ "https://nix-cache.lornu.ai" ];
     extra-trusted-public-keys = [
-      "stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A="
+      "lornu-1:FSWe0oOoYoYzbDU3XsZOoUz6LYouAKynidEOop1Q8yc="
     ];
   };
 


### PR DESCRIPTION
## Summary
- Point all Nix substituters at `https://nix-cache.lornu.ai`
- Trust the `lornu-1` signing key instead of stevedores cache keys
- Remove transitional `nix-cache.stevedores.org` fallback where present

## Test plan
- [ ] `nix flake check` (or repo CI) resolves store paths from `nix-cache.lornu.ai`
- [ ] No references to `nix-cache.stevedores.org` remain in changed files

Made with [Cursor](https://cursor.com)